### PR TITLE
Fix aspect corner dragging

### DIFF
--- a/src/Main/UserInterface/Components/Viewport/init.luau
+++ b/src/Main/UserInterface/Components/Viewport/init.luau
@@ -176,7 +176,7 @@ local function Viewport(props: Props)
 							local isDiagonal = directionAbsSum >= 2
 
 							if isDiagonal then
-								local projectionAxis = prevSize.Unit
+								local projectionAxis = (prevSize * direction).Unit
 								delta2 = delta2:Dot(projectionAxis) * projectionAxis
 							end
 						end


### PR DESCRIPTION
The projection axis used for maintaining the aspect ratio when dragging from corners was not accounting for the top right and bottom left corners. By multiplying the projection axis against the drag direction we get the correct projection axis.