### PR TITLE
Add upload button in local plugin

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -22,6 +22,8 @@
         "pngify",
         "rbxasset",
         "rbxassetid",
+        "rbxm",
+        "rbxmx",
         "readu32",
         "readu8",
         "resampler",

--- a/src/Main/UserInterface/Components/Gallery/ActionBar.luau
+++ b/src/Main/UserInterface/Components/Gallery/ActionBar.luau
@@ -7,7 +7,8 @@ local React = require(pluginRoot.Packages.React)
 
 local Image = require(pluginRoot.Utilities.Image)
 
-local UPLOADING_ENABLED = false
+local uiRoot = script:FindFirstAncestor("UserInterface")
+local Hooks = require(uiRoot.Hooks)
 
 export type UploadInfo = {
 	Title: string,
@@ -29,9 +30,10 @@ export type Props = {
 
 local function ActionBar(props: Props)
 	local theme = StudioComponents.useTheme()
+	local isLocalPlugin = Hooks.useIsLocalPlugin()
 
 	local uploadIcon = assert(Lucide.GetAsset("upload", 16))
-	local uploadDisabled = not (UPLOADING_ENABLED and not props.Disabled and props.EditableImage)
+	local uploadDisabled = not (not props.Disabled and props.EditableImage)
 
 	return React.createElement("Frame", {
 		AnchorPoint = props.AnchorPoint,
@@ -54,7 +56,7 @@ local function ActionBar(props: Props)
 			Padding = UDim.new(0, 4),
 		}),
 
-		Upload = UPLOADING_ENABLED and React.createElement(StudioComponents.MainButton, {
+		Upload = isLocalPlugin and React.createElement(StudioComponents.MainButton, {
 			LayoutOrder = -1,
 			Size = UDim2.new(0, 70, 1, 0),
 			AnchorPoint = Vector2.new(1, 0.5),

--- a/src/Main/UserInterface/Hooks/init.luau
+++ b/src/Main/UserInterface/Hooks/init.luau
@@ -8,4 +8,6 @@ return {
 
 	usePhotoFlag = require(script.usePhotoFlag),
 	usePhotoConfiguration = require(script.usePhotoConfiguration),
+
+	useIsLocalPlugin = require(script.useIsLocalPlugin),
 }

--- a/src/Main/UserInterface/Hooks/useIsLocalPlugin.luau
+++ b/src/Main/UserInterface/Hooks/useIsLocalPlugin.luau
@@ -1,0 +1,22 @@
+--!strict
+
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local StudioComponents = require(pluginRoot.Packages.StudioComponents)
+
+local function useIsLocalPlugin()
+	local plugin = StudioComponents.usePlugin() :: Plugin?
+	local pluginName = plugin and plugin.Name
+
+	if pluginName then
+		return not not (
+			pluginName:find(".rbxm$")
+			or pluginName:find(".rbxmx$")
+			or pluginName:find(".lua$")
+			or pluginName:find(".luau$")
+		)
+	end
+
+	return false
+end
+
+return useIsLocalPlugin


### PR DESCRIPTION
This PR adds a new hook that can tell if the plugin is locally installed or not. This is then used to display the upload button for users that have the plugin locally installed.