### PR TITLE
Add alpha bleed thickness

### DIFF
--- a/src/Main/Photo/Captures/init.luau
+++ b/src/Main/Photo/Captures/init.luau
@@ -20,7 +20,7 @@ local function _convertToWhite(img: Image.Image)
 	end
 end
 
-local function alphaBleedSerial(img: Image.Image, thickness: number)
+local function alphaBleed(img: Image.Image, thickness: number)
 	local width, height = img.size.X, img.size.Y
 
 	local visited = {}
@@ -101,7 +101,7 @@ local function wrap<T...>(callback: (T...) -> ...Image.Image)
 	local function wrapped(...: T...)
 		local results = { callback(...) }
 		for _, img in results do
-			alphaBleedSerial(img, 1)
+			alphaBleed(img, 1)
 		end
 		return results
 	end


### PR DESCRIPTION
This PR adjusts the alpha bleed function to allow only bleeding a set thickness. This results in performance gains as only one pixel is needed.

See the read me of this repository for more info.
https://github.com/EgoMoose/alpha-bleed/tree/main

Additionally, it adjusts the math behind calculating transparent pixel colors. Previously the algorithm was sampling neighboring pixels that it shouldn't have been.

Old:
![lf46YhsAP9](https://github.com/user-attachments/assets/43516824-effe-44ed-88d1-90b9f9785107)

New:
![RobloxStudioBeta_5Y8jBJi7oe](https://github.com/user-attachments/assets/df13f8cf-a4bf-49ee-8f6b-29d246163d58)
