### PR TITLE
Show upload button if has create asset perms

### DIFF
--- a/src/Main/UserInterface/Components/Gallery/ActionBar.luau
+++ b/src/Main/UserInterface/Components/Gallery/ActionBar.luau
@@ -30,7 +30,7 @@ export type Props = {
 
 local function ActionBar(props: Props)
 	local theme = StudioComponents.useTheme()
-	local isLocalPlugin = Hooks.useIsLocalPlugin()
+	local hasCreateAssetPermission = Hooks.useHasCreateAssetPermission()
 
 	local uploadIcon = assert(Lucide.GetAsset("upload", 16))
 	local uploadDisabled = not (not props.Disabled and props.EditableImage)
@@ -56,7 +56,7 @@ local function ActionBar(props: Props)
 			Padding = UDim.new(0, 4),
 		}),
 
-		Upload = isLocalPlugin and React.createElement(StudioComponents.MainButton, {
+		Upload = hasCreateAssetPermission and React.createElement(StudioComponents.MainButton, {
 			LayoutOrder = -1,
 			Size = UDim2.new(0, 70, 1, 0),
 			AnchorPoint = Vector2.new(1, 0.5),

--- a/src/Main/UserInterface/Hooks/init.luau
+++ b/src/Main/UserInterface/Hooks/init.luau
@@ -11,4 +11,5 @@ return {
 
 	usePlugin = require(script.usePlugin),
 	useIsLocalPlugin = require(script.useIsLocalPlugin),
+	useHasCreateAssetPermission = require(script.useHasCreateAssetPermission),
 }

--- a/src/Main/UserInterface/Hooks/useHasCreateAssetPermission.luau
+++ b/src/Main/UserInterface/Hooks/useHasCreateAssetPermission.luau
@@ -1,0 +1,36 @@
+--!strict
+
+local AssetService = game:GetService("AssetService") :: AssetService
+
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local React = require(pluginRoot.Packages.React)
+
+local success = false
+local finished = Instance.new("BindableEvent")
+task.spawn(function()
+	local model = Instance.new("Model")
+	-- attempt to upload something as Roblox which will error if the api isn't available this includes uploading from a cloud plugin
+	-- the request itself will fail but not error if the api is enabled b/c chances are that you're not roblox
+	success = pcall(AssetService.CreateAssetAsync, AssetService, model, Enum.AssetType.Model, { CreatorId = 1 })
+	model:Destroy()
+	finished:Fire()
+end)
+
+local function useHasCreateAssetPermission()
+	local hasPermission, setHasPermission = React.useState(success)
+
+	React.useEffect(function()
+		setHasPermission(success)
+		local connection = finished.Event:Connect(function()
+			setHasPermission(success)
+		end)
+
+		return function()
+			connection:Disconnect()
+		end
+	end)
+
+	return hasPermission
+end
+
+return useHasCreateAssetPermission


### PR DESCRIPTION
This PR adds a check for if the `CreateAssetAsync` API is available in the user's plugin context. It then uses this value to show or hide the upload button.