### PR TITLE
Enable parallel composers

### DIFF
--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleed/Bleed.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleed/Bleed.luau
@@ -59,10 +59,9 @@ local function bleed(img: Image.Image, visited: buffer, pending: { number })
 	-- not really taking advantage of parallel luau here
 	-- however, by using a worker we stop studio from getting hung up
 
-	local scheduler = Parallel.new(1, required)
+	local scheduler = Parallel.cached(1, required)
 	scheduler:Schedule(img.buffer, img.size, visited, pending)
-	local packedResults = scheduler:WorkDeferred()
-	scheduler:Destroy()
+	local packedResults = scheduler:Work()
 
 	local result = Image.fromBuffer(packedResults[1](), img.size)
 	result.templateUri = img.templateUri

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleed/FirstPass.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleed/FirstPass.luau
@@ -99,14 +99,13 @@ local required = {
 }
 
 local function firstPass(img: Image.Image)
-	local scheduler = Parallel.new(32, required)
+	local scheduler = Parallel.cached(32, required)
 
 	for _, chunk in img:Split(scheduler:GetActorCount(), 1) do
 		scheduler:Schedule(chunk.buffer, chunk.size, chunk.crop, chunk.minIndex)
 	end
 
-	local packedResults = scheduler:WorkDeferred()
-	scheduler:Destroy()
+	local packedResults = scheduler:Work()
 
 	local pending = {}
 	local copyIndex = 0

--- a/src/Main/Photo/Captures/Composers/Parallel/ReverseBlend.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/ReverseBlend.luau
@@ -100,7 +100,7 @@ local function reverseBlendParallel(
 	onBlack: Image.Image?,
 	colorCorrection: ColorCorrectionEffect
 )
-	local scheduler = Parallel.new(32, required)
+	local scheduler = Parallel.cached(32, required)
 
 	local splitOnWhiteRetro = onWhiteRetro:Split(scheduler:GetActorCount())
 	local splitOnBlackRetro = onBlackRetro:Split(scheduler:GetActorCount())
@@ -120,8 +120,7 @@ local function reverseBlendParallel(
 		)
 	end
 
-	local packedResults = scheduler:WorkDeferred()
-	scheduler:Destroy()
+	local packedResults = scheduler:Work()
 
 	local copyIndex = 0
 	local resultBuffer = buffer.create(onWhiteRetro:GetNumberOfPixels() * 4)

--- a/src/Main/Photo/Captures/Composers/init.luau
+++ b/src/Main/Photo/Captures/Composers/init.luau
@@ -4,7 +4,7 @@ local serialFolder = script.Serial
 local parallelFolder = script.Parallel
 
 return {
-	alphaBleed = require(serialFolder.AlphaBleed),
-	reverseBlend = require(serialFolder.ReverseBlend),
+	alphaBleed = require(parallelFolder.AlphaBleed),
+	reverseBlend = require(parallelFolder.ReverseBlend),
 	fullyOpaque = require(serialFolder.FullyOpaque),
 }

--- a/src/Utilities/Image.luau
+++ b/src/Utilities/Image.luau
@@ -229,12 +229,12 @@ function ImageClass.Split(self: Image, n: number, yPadding: number?)
 	local height = self.size.Y
 
 	local yPad = yPadding or 0
-	local linesPerWorker = math.ceil(height / n)
+	local linesPerWorker = math.floor(height / n)
 
 	local chunks = {}
 	for i = 1, n do
 		local start = ((i - 1) * linesPerWorker) + 1
-		local finish = math.min(height, (i * linesPerWorker))
+		local finish = math.min(height, if i == n then height else (i * linesPerWorker))
 
 		if start <= finish then
 			local startPadded = math.max(1, start - yPad)

--- a/src/Utilities/Parallel/Worker.luau
+++ b/src/Utilities/Parallel/Worker.luau
@@ -11,4 +11,6 @@ return function(script: LuaSourceContainer)
 	actor:BindToMessageParallel("Work", function(index, ...)
 		resultsBinding:Fire(index, required.callback(...))
 	end)
+
+	actor:SetAttribute("IsReady", true)
 end

--- a/src/Utilities/Parallel/init.luau
+++ b/src/Utilities/Parallel/init.luau
@@ -22,7 +22,7 @@ export type Parallel<T..., U...> = typeof(setmetatable(
 		schedules: { [Actor]: { () -> T... } },
 		isWorking: boolean,
 
-		callback: (T...) -> U...,
+		required: Required<T..., U...>,
 
 		module: ModuleScript,
 		resultsBinding: BindableEvent,
@@ -38,10 +38,10 @@ function ParallelStatic.new<T..., U...>(n: number, required: Required<T..., U...
 	self.schedules = {}
 	self.isWorking = false
 
-	self.callback = required.callback
+	self.required = required
 
 	self.module = required.script:Clone()
-	self.module.Name = "ParallelModule"
+	self.module.Name = `Parallel_{required.script.Name}`
 	self.module.Archivable = false
 	self.module.Parent = script
 
@@ -76,7 +76,31 @@ function ParallelStatic.new<T..., U...>(n: number, required: Required<T..., U...
 		self.schedules[actor] = {}
 	end
 
+	for _, actor in self.actors do
+		while not actor:GetAttribute("IsReady") do
+			actor:GetAttributeChangedSignal("IsReady"):Wait()
+		end
+	end
+
 	return self
+end
+
+local ParallelCache: { [ModuleScript]: { Parallel<...any, ...any> } } = {}
+
+function ParallelStatic.cached<T..., U...>(n: number, required: Required<T..., U...>)
+	local cache = ParallelCache[required.script]
+	if not cache then
+		cache = {}
+		ParallelCache[required.script] = cache
+	end
+
+	local parallel: Parallel<T..., U...> = cache[n]
+	if not parallel then
+		parallel = ParallelStatic.new(n, required)
+		cache[n] = parallel
+	end
+
+	return parallel
 end
 
 function ParallelStatic.cast<T..., U..., V..., W...>(required: Required<T..., U...>, callback: (V...) -> W...)
@@ -126,7 +150,33 @@ local function packAsCallback<T...>(...: T...): () -> T...
 	end
 end
 
-local function work<T..., U...>(self: Parallel<T..., U...>)
+-- Public
+
+function ParallelClass.GetActorCount<T..., U...>(self: Parallel<T..., U...>)
+	return #self.actors
+end
+
+function ParallelClass.Schedule<T..., U...>(self: Parallel<T..., U...>, ...: T...)
+	self.ticket = self.ticket + 1
+	local myTicket = self.ticket
+
+	local actorIndex = ((myTicket - 1) % #self.actors) + 1
+	local actor = self.actors[actorIndex]
+
+	table.insert(self.schedules[actor], packAsCallback(...))
+end
+
+function ParallelClass.Clear<T..., U...>(self: Parallel<T..., U...>)
+	self.ticket = 0
+	for actor, _ in self.schedules do
+		table.clear(self.schedules[actor])
+	end
+end
+
+function ParallelClass.Work<T..., U...>(self: Parallel<T..., U...>)
+	assert(not self.isWorking, "Already working!")
+	self.isWorking = true
+
 	local expectations = {}
 	for i, actor in self.actors do
 		local schedule = self.schedules[actor]
@@ -147,67 +197,11 @@ local function work<T..., U...>(self: Parallel<T..., U...>)
 		end
 	end
 
-	for actor, _ in self.schedules do
-		table.clear(self.schedules[actor])
-	end
+	self:Clear()
 
 	local results = {}
 	for i, expect in expectations do
 		results[i] = expect()
-	end
-
-	return results
-end
-
--- Public
-
-function ParallelClass.GetActorCount<T..., U...>(self: Parallel<T..., U...>)
-	return #self.actors
-end
-
-function ParallelClass.Schedule<T..., U...>(self: Parallel<T..., U...>, ...: T...)
-	self.ticket = self.ticket + 1
-	local myTicket = self.ticket
-
-	local actorIndex = ((myTicket - 1) % #self.actors) + 1
-	local actor = self.actors[actorIndex]
-
-	table.insert(self.schedules[actor], packAsCallback(...))
-end
-
-function ParallelClass.Work<T..., U...>(self: Parallel<T..., U...>)
-	assert(not self.isWorking, "Already working!")
-	self.isWorking = true
-
-	local results = work(self)
-
-	self.isWorking = false
-	return results
-end
-
-function ParallelClass.WorkDeferred<T..., U...>(self: Parallel<T..., U...>)
-	assert(not self.isWorking, "Already working!")
-	self.isWorking = true
-
-	local results
-	local success, err: string?
-	local complete = false
-	local thread = coroutine.running()
-	task.defer(function()
-		success, err = pcall(function()
-			results = work(self)
-		end)
-
-		complete = true
-		task.spawn(thread)
-	end)
-
-	while not complete do
-		coroutine.yield()
-	end
-
-	if not success then
-		error(err)
 	end
 
 	self.isWorking = false
@@ -215,6 +209,14 @@ function ParallelClass.WorkDeferred<T..., U...>(self: Parallel<T..., U...>)
 end
 
 function ParallelClass.Destroy<T..., U...>(self: Parallel<T..., U...>)
+	local cache = ParallelCache[self.required.script]
+	if cache then
+		cache[#self.actors] = nil
+		if not next(cache) then
+			ParallelCache[self.required.script] = nil
+		end
+	end
+
 	self.resultsBinding:Destroy()
 	self.module:Destroy()
 	self.actors = {}


### PR DESCRIPTION
This PR turns on parallel composers as they are now fixed / enabled. This vastly increases the speed of reverse blending.