### PR TITLE
Handle os scaled fullscreen capture

### DIFF
--- a/src/Main/Bindings/Invocations/CaptureViewport.luau
+++ b/src/Main/Bindings/Invocations/CaptureViewport.luau
@@ -25,11 +25,23 @@ local function callback(rect: Rect, captureType: Captures.ViewportCaptureTypes)
 
 	local camera = workspace.CurrentCamera
 	local viewportSize = camera.ViewportSize
-	local corner = ((viewportSize * scaleOS) - viewportSize) / 2
 
-	local scaledRectAbsPosition = (rect.Min + corner)
-	local scaledRectAbsSize = (rect.Max + corner) - scaledRectAbsPosition
-	local scaledRect = RenderRect.fromAbs(scaledRectAbsPosition, scaledRectAbsSize)
+	local scaledRect: Rect
+	if rect.Min == Vector2.zero and rect.Max == viewportSize then
+		-- stylua: ignore
+		local scaledViewportSize = Vector2.new(
+			math.round(viewportSize.X * scaleOS.X),
+			math.round(viewportSize.Y * scaleOS.Y)
+		)
+
+		scaledRect = Rect.new(Vector2.zero, scaledViewportSize)
+	else
+		local corner = ((viewportSize * scaleOS) - viewportSize) / 2
+
+		local scaledRectAbsPosition = (rect.Min + corner)
+		local scaledRectAbsSize = (rect.Max + corner) - scaledRectAbsPosition
+		scaledRect = RenderRect.fromAbs(scaledRectAbsPosition, scaledRectAbsSize)
+	end
 
 	local prevCameraCF = camera.CFrame
 	local prevCameraType = camera.CameraType

--- a/src/Main/Photo/Captures/Screenshot.luau
+++ b/src/Main/Photo/Captures/Screenshot.luau
@@ -79,8 +79,20 @@ function Screenshot.isFullscreenAllowed()
 end
 
 function Screenshot.isFullscreenRect(rect: Rect)
+	if not Screenshot.isFullscreenAllowed() then
+		return false
+	end
+
+	local scaleOS = Configuration.get().ScaleOS
 	local viewportSize = workspace.CurrentCamera.ViewportSize :: Vector2
-	return ALLOW_FULLSCREEN and rect.Min == Vector2.zero and rect.Max == viewportSize
+
+	-- stylua: ignore
+	local scaledViewportSize = Vector2.new(
+		math.round(viewportSize.X * scaleOS.X),
+		math.round(viewportSize.Y * scaleOS.Y)
+	)
+
+	return rect.Min == Vector2.zero and rect.Max == scaledViewportSize
 end
 
 function Screenshot.rect(rect: Rect)


### PR DESCRIPTION
Fixes the case where fullscreen capture is requested through binding, but OS scale trys to crop the size.