### PR TITLE
Fix crop viewport rounding issue

### DIFF
--- a/src/Main/UserInterface/Components/CroppedViewport/init.luau
+++ b/src/Main/UserInterface/Components/CroppedViewport/init.luau
@@ -101,14 +101,14 @@ local function CroppedViewport(props: Props & { ViewportSize: Vector2 })
 
 	-- this is what renders
 	local lenseAbsSize = useLenseSize(size, viewportSize, 1 / scaleOS)
-	local lenseAbsPosition = ((viewportSize - lenseAbsSize) / 2):Floor()
+	local lenseAbsPosition = (viewportSize - lenseAbsSize) / 2
 	local lenseRect = RenderRect.fromAbs(lenseAbsPosition, lenseAbsSize)
 	local lenseUDim2Size = UDim2.fromOffset(lenseRect.Width, lenseRect.Height)
 	local lenseUDim2Position = UDim2.fromOffset(lenseRect.Min.X, lenseRect.Min.Y)
 
 	-- this is used for displaying dimensions + capture rect
 	local scaledLenseAbsSize = useLenseSize(size, scaledViewport, Vector2.new(1, 1))
-	local scaledLenseAbsPosition = ((scaledViewport - scaledLenseAbsSize) / 2):Floor()
+	local scaledLenseAbsPosition = (scaledViewport - scaledLenseAbsSize) / 2
 	local scaledLenseRect = RenderRect.fromAbs(scaledLenseAbsPosition, scaledLenseAbsSize)
 	local scaledLenseRectSize = Vector2.new(scaledLenseRect.Width, scaledLenseRect.Height)
 


### PR DESCRIPTION
The abs position was floored (which was incorrect). This could cause a blue line from the UI to appear.

For example, with OS scale `(1.5, 1.5)` in a 1080p emulated device attempting to capture 512 x 512.