### PR TITLE
Refactor parallel module

### DIFF
--- a/.vscode/selene.yml
+++ b/.vscode/selene.yml
@@ -5,3 +5,10 @@ globals:
   require:
     args:
     - type: string
+
+  # changes assert rules to allow optional second arg
+  assert:
+    args:
+      - type: any
+      - type: string
+        required: false

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleed/Bleed/Worker.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleed/Bleed/Worker.luau
@@ -1,14 +1,13 @@
 --!strict
 
 local pluginRoot = script:FindFirstAncestor("PluginRoot")
-local Parallel = require(pluginRoot.Utilities.Parallel)
 local Image = require(pluginRoot.Utilities.Image)
 
 local HAS_VISITED = bit32.lshift(1, 0)
 local CAN_SAMPLE = bit32.lshift(1, 1)
 local BOTH = bit32.bor(HAS_VISITED, CAN_SAMPLE)
 
-local function doWork(imgBuffer: buffer, imgSize: Vector2, visited: buffer, pending: { number })
+local function workerAction(imgBuffer: buffer, imgSize: Vector2, visited: buffer, pending: { number })
 	local img = Image.fromBuffer(imgBuffer, imgSize)
 
 	while #pending > 0 do
@@ -50,22 +49,4 @@ local function doWork(imgBuffer: buffer, imgSize: Vector2, visited: buffer, pend
 	return img.buffer
 end
 
-local required = {
-	script = script,
-	callback = doWork,
-}
-
-local function bleed(img: Image.Image, visited: buffer, pending: { number })
-	-- not really taking advantage of parallel luau here
-	-- however, by using a worker we stop studio from getting hung up
-
-	local scheduler = Parallel.cached(1, required)
-	scheduler:Schedule(img.buffer, img.size, visited, pending)
-	local packedResults = scheduler:Work()
-
-	local result = Image.fromBuffer(packedResults[1](), img.size)
-	result.templateUri = img.templateUri
-	return result
-end
-
-return Parallel.cast(required, bleed)
+return workerAction

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleed/Bleed/init.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleed/Bleed/init.luau
@@ -1,0 +1,26 @@
+--!strict
+
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local Parallel = require(pluginRoot.Utilities.Parallel)
+local Image = require(pluginRoot.Utilities.Image)
+
+type WorkerAction = typeof(require(script.Worker))
+
+local scheduler = Parallel.new(1, {
+	script = script.Worker,
+	typecast = (nil :: any) :: WorkerAction,
+})
+
+local function parallelize(img: Image.Image, visited: buffer, pending: { number })
+	-- not really taking advantage of parallel luau here
+	-- however, by using a worker we stop studio from getting hung up
+
+	scheduler:Schedule(img.buffer, img.size, visited, pending)
+	local packedResults = scheduler:Work()
+
+	local result = Image.fromBuffer(packedResults[1](), img.size)
+	result.templateUri = img.templateUri
+	return result
+end
+
+return parallelize

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleed/FirstPass/Worker.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleed/FirstPass/Worker.luau
@@ -1,7 +1,6 @@
 --!strict
 
 local pluginRoot = script:FindFirstAncestor("PluginRoot")
-local Parallel = require(pluginRoot.Utilities.Parallel)
 local Image = require(pluginRoot.Utilities.Image)
 
 local HAS_VISITED = bit32.lshift(1, 0)
@@ -64,7 +63,7 @@ local function integralImage(img: Image.Image)
 	return readRadius
 end
 
-local function doWork(chunkBuffer: buffer, chunkSize: Vector2, crop: Rect, minIndex: number)
+local function workerAction(chunkBuffer: buffer, chunkSize: Vector2, crop: Rect, minIndex: number)
 	local chunkImg = Image.fromBuffer(chunkBuffer, chunkSize)
 	local readRadius = integralImage(chunkImg)
 
@@ -93,31 +92,4 @@ local function doWork(chunkBuffer: buffer, chunkSize: Vector2, crop: Rect, minIn
 	return visited, pending
 end
 
-local required = {
-	script = script,
-	callback = doWork,
-}
-
-local function firstPass(img: Image.Image)
-	local scheduler = Parallel.cached(32, required)
-
-	for _, chunk in img:Split(scheduler:GetActorCount(), 1) do
-		scheduler:Schedule(chunk.buffer, chunk.size, chunk.crop, chunk.minIndex)
-	end
-
-	local packedResults = scheduler:Work()
-
-	local pending = {}
-	local copyIndex = 0
-	local visited = buffer.create(img:GetNumberOfPixels())
-	for _, unpackResult in packedResults do
-		local visitedChunk, pendingChunk = unpackResult()
-		buffer.copy(visited, copyIndex, visitedChunk)
-		copyIndex = copyIndex + buffer.len(visitedChunk)
-		table.move(pendingChunk, 1, #pendingChunk, #pending + 1, pending)
-	end
-
-	return visited, pending
-end
-
-return Parallel.cast(required, firstPass)
+return workerAction

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleed/FirstPass/init.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleed/FirstPass/init.luau
@@ -1,0 +1,34 @@
+--!strict
+
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local Parallel = require(pluginRoot.Utilities.Parallel)
+local Image = require(pluginRoot.Utilities.Image)
+
+type WorkerAction = typeof(require(script.Worker))
+
+local scheduler = Parallel.new(32, {
+	script = script.Worker,
+	typecast = (nil :: any) :: WorkerAction,
+})
+
+local function parallelize(img: Image.Image)
+	for _, chunk in img:Split(scheduler:GetActorCount(), 1) do
+		scheduler:Schedule(chunk.buffer, chunk.size, chunk.crop, chunk.minIndex)
+	end
+
+	local packedResults = scheduler:Work()
+
+	local pending = {}
+	local copyIndex = 0
+	local visited = buffer.create(img:GetNumberOfPixels())
+	for _, unpackResult in packedResults do
+		local visitedChunk, pendingChunk = unpackResult()
+		buffer.copy(visited, copyIndex, visitedChunk)
+		copyIndex = copyIndex + buffer.len(visitedChunk)
+		table.move(pendingChunk, 1, #pendingChunk, #pending + 1, pending)
+	end
+
+	return visited, pending
+end
+
+return parallelize

--- a/src/Main/Photo/Captures/Composers/Parallel/ReverseBlend/Worker.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/ReverseBlend/Worker.luau
@@ -1,7 +1,6 @@
 --!strict
 
 local pluginRoot = script:FindFirstAncestor("PluginRoot")
-local Parallel = require(pluginRoot.Utilities.Parallel)
 local Image = require(pluginRoot.Utilities.Image)
 
 local COMPARE_MARGIN = 0
@@ -18,7 +17,7 @@ local function compareByMargin(a: { number }, b: { number }, margin: number): bo
 	)
 end
 
-local function doWork(
+local function workerAction(
 	size: Vector2,
 	colorCorrection: ColorCorrectionEffect,
 	whiteRetroBuffer: buffer,
@@ -89,50 +88,4 @@ local function doWork(
 	return onBlack.buffer
 end
 
-local required = {
-	script = script,
-	callback = doWork,
-}
-
-local function reverseBlendParallel(
-	onWhiteRetro: Image.Image,
-	onBlackRetro: Image.Image,
-	onBlack: Image.Image?,
-	colorCorrection: ColorCorrectionEffect
-)
-	local scheduler = Parallel.cached(32, required)
-
-	local splitOnWhiteRetro = onWhiteRetro:Split(scheduler:GetActorCount())
-	local splitOnBlackRetro = onBlackRetro:Split(scheduler:GetActorCount())
-	local splitOnBlack = if onBlack then onBlack:Split(scheduler:GetActorCount()) else {}
-
-	for i = 1, #splitOnWhiteRetro do
-		local onWhiteRetroChunk = splitOnWhiteRetro[i]
-		local onBlackRetroChunk = splitOnBlackRetro[i]
-		local onBlackChunk = splitOnBlack[i]
-
-		scheduler:Schedule(
-			onWhiteRetroChunk.size,
-			colorCorrection,
-			onWhiteRetroChunk.buffer,
-			onBlackRetroChunk.buffer,
-			if onBlackChunk then onBlackChunk.buffer else nil
-		)
-	end
-
-	local packedResults = scheduler:Work()
-
-	local copyIndex = 0
-	local resultBuffer = buffer.create(onWhiteRetro:GetNumberOfPixels() * 4)
-	for _, unpackResult in packedResults do
-		local commitBuffer = unpackResult()
-		buffer.copy(resultBuffer, copyIndex, commitBuffer)
-		copyIndex = copyIndex + buffer.len(commitBuffer)
-	end
-
-	local result = Image.fromBuffer(resultBuffer, onWhiteRetro.size)
-	result.templateUri = onWhiteRetro.templateUri
-	return result
-end
-
-return Parallel.cast(required, reverseBlendParallel)
+return workerAction

--- a/src/Main/Photo/Captures/Composers/Parallel/ReverseBlend/init.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/ReverseBlend/init.luau
@@ -1,0 +1,53 @@
+--!strict
+
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local Parallel = require(pluginRoot.Utilities.Parallel)
+local Image = require(pluginRoot.Utilities.Image)
+
+type WorkerAction = typeof(require(script.Worker))
+
+local scheduler = Parallel.new(32, {
+	script = script.Worker,
+	typecast = (nil :: any) :: WorkerAction,
+})
+
+local function parallelize(
+	onWhiteRetro: Image.Image,
+	onBlackRetro: Image.Image,
+	onBlack: Image.Image?,
+	colorCorrection: ColorCorrectionEffect
+)
+	local splitOnWhiteRetro = onWhiteRetro:Split(scheduler:GetActorCount())
+	local splitOnBlackRetro = onBlackRetro:Split(scheduler:GetActorCount())
+	local splitOnBlack = if onBlack then onBlack:Split(scheduler:GetActorCount()) else {}
+
+	for i = 1, #splitOnWhiteRetro do
+		local onWhiteRetroChunk = splitOnWhiteRetro[i]
+		local onBlackRetroChunk = splitOnBlackRetro[i]
+		local onBlackChunk = splitOnBlack[i]
+
+		scheduler:Schedule(
+			onWhiteRetroChunk.size,
+			colorCorrection,
+			onWhiteRetroChunk.buffer,
+			onBlackRetroChunk.buffer,
+			if onBlackChunk then onBlackChunk.buffer else nil
+		)
+	end
+
+	local packedResults = scheduler:Work()
+
+	local copyIndex = 0
+	local resultBuffer = buffer.create(onWhiteRetro:GetNumberOfPixels() * 4)
+	for _, unpackResult in packedResults do
+		local commitBuffer = unpackResult()
+		buffer.copy(resultBuffer, copyIndex, commitBuffer)
+		copyIndex = copyIndex + buffer.len(commitBuffer)
+	end
+
+	local result = Image.fromBuffer(resultBuffer, onWhiteRetro.size)
+	result.templateUri = onWhiteRetro.templateUri
+	return result
+end
+
+return parallelize

--- a/src/Utilities/Parallel/Worker.luau
+++ b/src/Utilities/Parallel/Worker.luau
@@ -2,14 +2,18 @@
 
 return function(script: LuaSourceContainer)
 	local actor = assert(script:GetActor(), "No actor found.")
-	local module = assert(actor.Parent and actor.Parent.Parent, "No module found.")
-	local resultsBinding = assert(module:FindFirstChild("Results"), "Not Results instance found.")
-	assert(resultsBinding:IsA("BindableEvent"), "Not a BindableEvent.")
+	local moduleRef = assert(actor.Parent and actor.Parent.Parent, "No module found.")
+	local binding = assert(moduleRef:FindFirstChild("Binding"), "Not binding instance found.")
 
-	local required = require(module) :: any
+	assert(moduleRef:IsA("ObjectValue"), "Not a ObjectValue.")
+	assert(binding:IsA("BindableEvent"), "Not a BindableEvent.")
 
+	local module = assert(moduleRef.Value, "No value in the ObjectValue.")
+	assert(module:IsA("ModuleScript"), "ModuleRef Value is not a ModuleScript.")
+
+	local workerAction = require(module) :: any
 	actor:BindToMessageParallel("Work", function(index, ...)
-		resultsBinding:Fire(index, required.callback(...))
+		binding:Fire(index, workerAction(...))
 	end)
 
 	actor:SetAttribute("IsReady", true)

--- a/src/Utilities/Parallel/init.luau
+++ b/src/Utilities/Parallel/init.luau
@@ -12,7 +12,7 @@ ParallelClass.ClassName = "Parallel"
 
 export type Required<T..., U...> = {
 	script: ModuleScript,
-	callback: (T...) -> U...,
+	typecast: (T...) -> U...,
 }
 
 export type Parallel<T..., U...> = typeof(setmetatable(
@@ -24,8 +24,8 @@ export type Parallel<T..., U...> = typeof(setmetatable(
 
 		required: Required<T..., U...>,
 
-		module: ModuleScript,
-		resultsBinding: BindableEvent,
+		moduleRef: ObjectValue,
+		binding: BindableEvent,
 	},
 	ParallelClass
 ))
@@ -40,21 +40,22 @@ function ParallelStatic.new<T..., U...>(n: number, required: Required<T..., U...
 
 	self.required = required
 
-	self.module = required.script:Clone()
-	self.module.Name = `Parallel_{required.script.Name}`
-	self.module.Archivable = false
-	self.module.Parent = script
+	self.moduleRef = Instance.new("ObjectValue")
+	self.moduleRef.Name = `Parallel_{required.script.Name}`
+	self.moduleRef.Value = required.script
+	self.moduleRef.Archivable = false
+	self.moduleRef.Parent = script
 
-	self.resultsBinding = Instance.new("BindableEvent")
-	self.resultsBinding.Name = "Results"
-	self.resultsBinding.Parent = self.module
+	self.binding = Instance.new("BindableEvent")
+	self.binding.Name = "Binding"
+	self.binding.Parent = self.moduleRef
 
 	local workerModule = script.Worker:Clone()
-	workerModule.Parent = self.module
+	workerModule.Parent = self.moduleRef
 
 	local actorFolder = Instance.new("Folder")
 	actorFolder.Name = "Actors"
-	actorFolder.Parent = self.module
+	actorFolder.Parent = self.moduleRef
 
 	local template = script.ClientWorker
 	if script:FindFirstAncestorWhichIsA("Plugin") then
@@ -83,34 +84,6 @@ function ParallelStatic.new<T..., U...>(n: number, required: Required<T..., U...
 	end
 
 	return self
-end
-
-local ParallelCache: { [ModuleScript]: { Parallel<...any, ...any> } } = {}
-
-function ParallelStatic.cached<T..., U...>(n: number, required: Required<T..., U...>)
-	local cache = ParallelCache[required.script]
-	if not cache then
-		cache = {}
-		ParallelCache[required.script] = cache
-	end
-
-	local parallel: Parallel<T..., U...> = cache[n]
-	if not parallel then
-		parallel = ParallelStatic.new(n, required)
-		cache[n] = parallel
-	end
-
-	return parallel
-end
-
-function ParallelStatic.cast<T..., U..., V..., W...>(required: Required<T..., U...>, callback: (V...) -> W...)
-	local meta = setmetatable(table.clone(required), {
-		__call = function(self, ...)
-			return callback(...)
-		end,
-	})
-
-	return (meta :: any) :: (V...) -> W...
 end
 
 -- Private
@@ -186,7 +159,7 @@ function ParallelClass.Work<T..., U...>(self: Parallel<T..., U...>)
 			expectations[k] = expect
 
 			local connection
-			connection = self.resultsBinding.Event:Connect(function(index: number, ...: any)
+			connection = self.binding.Event:Connect(function(index: number, ...: any)
 				if k == index then
 					complete(packAsCallback(...) :: () -> U...)
 					connection:Disconnect()
@@ -209,16 +182,8 @@ function ParallelClass.Work<T..., U...>(self: Parallel<T..., U...>)
 end
 
 function ParallelClass.Destroy<T..., U...>(self: Parallel<T..., U...>)
-	local cache = ParallelCache[self.required.script]
-	if cache then
-		cache[#self.actors] = nil
-		if not next(cache) then
-			ParallelCache[self.required.script] = nil
-		end
-	end
-
-	self.resultsBinding:Destroy()
-	self.module:Destroy()
+	self.binding:Destroy()
+	self.moduleRef:Destroy()
 	self.actors = {}
 	self.schedules = {}
 end


### PR DESCRIPTION
This PR removes some of the nasty work regarding same module parallel code.

We now:
- Force the parallel module to use a seperate worker action module
- Reference said module without cloning and reparenting (i.e. object value) so that it can use relative paths