### PR TITLE
Fix cropped capture edges

### DIFF
--- a/src/Main/UserInterface/Components/CroppedViewport/init.luau
+++ b/src/Main/UserInterface/Components/CroppedViewport/init.luau
@@ -155,11 +155,10 @@ local function CroppedViewport(props: Props & { ViewportSize: Vector2 })
 				UIStroke = React.createElement("UIStroke", {
 					Thickness = 2,
 					Transparency = 0,
-					Color = Color3.new(1, 0, 0),
-					-- Color = theme:GetColor(
-					-- 	Enum.StudioStyleGuideColor.InputFieldBorder,
-					-- 	Enum.StudioStyleGuideModifier.Selected
-					-- ),
+					Color = theme:GetColor(
+						Enum.StudioStyleGuideColor.InputFieldBorder,
+						Enum.StudioStyleGuideModifier.Selected
+					),
 				}),
 			}),
 			Grabbers = React.createElement(Grabbers, {


### PR DESCRIPTION
In some cases (non `(1, 1)` os scale) the bright blue edges of the cropped viewport UI were being captured. 

This was brought to my attention by a mac user with `1800x1169` resolution causing an os scale value of `2, 2`. I was able to verify this on a mac, but I could also create the issue on windows by emulating that device and using an os scale value of `2, 2` or `1.5, 1.5`.

I was able to fix this by ensuring that the rendered capture frame was always rendered to its maximum possible size. The min corner is `math.floor`'d and the max corner is `math.ceil`'d. This technically means the rendered rect could be a pixel off depending on the conditions, but I figured only eagle eye'd users would notice this and if they really did care that much they'd probably opt for identity OS scaling.