### PR TITLE
Replace Future.raw -> Future.new

### DIFF
--- a/src/Main/Photo/Captures/Screenshot.luau
+++ b/src/Main/Photo/Captures/Screenshot.luau
@@ -20,7 +20,7 @@ local _bilinearScaleContext = Context.new(nil :: Vector2?)
 -- Private
 
 local function captureEditableImage()
-	local contentUriFuture = Future.raw() :: Future.Future<string>
+	local contentUriFuture = Future.new() :: Future.Future<string>
 	CaptureService:CaptureScreenshot(function(contentUri: string)
 		-- this is a significant bottleneck for speed
 		-- it can take roughly 0.3 seconds to complete

--- a/src/Main/Photo/Tools/PngServe.luau
+++ b/src/Main/Photo/Tools/PngServe.luau
@@ -40,8 +40,8 @@ end
 -- Public
 
 function PngServe.ping(port: number, timeout: number?)
-	local pingFuture = Future.raw()
-	local timeoutFuture = Future.raw()
+	local pingFuture = Future.new()
+	local timeoutFuture = Future.new()
 
 	if timeout and timeout > 0 then
 		task.delay(timeout, function()
@@ -74,8 +74,8 @@ function PngServe.ping(port: number, timeout: number?)
 end
 
 function PngServe.send(port: number, name: string, img: Image.Image, timeout: number?)
-	local sendFuture = Future.raw()
-	local timeoutFuture = Future.raw()
+	local sendFuture = Future.new()
+	local timeoutFuture = Future.new()
 
 	local resultFuture = Future.race({
 		sendFuture,
@@ -120,7 +120,7 @@ function PngServe.create(port: number)
 	end
 
 	return function(name: string, img: Image.Image)
-		local sendFuture = Future.raw()
+		local sendFuture = Future.new()
 		task.spawn(function()
 			local result = false
 			if pingFuture:expect() then

--- a/src/Utilities/Future.luau
+++ b/src/Utilities/Future.luau
@@ -19,7 +19,7 @@ export type Future<T> = typeof(setmetatable(
 
 -- Constructors
 
-function FutureStatic.raw<T>()
+function FutureStatic.new<T>()
 	local self = setmetatable({}, FutureClass) :: Future<T>
 
 	self._typecast = (nil :: any) :: T
@@ -32,7 +32,7 @@ function FutureStatic.raw<T>()
 end
 
 function FutureStatic.completed<T>(value: T)
-	local future = FutureStatic.raw()
+	local future = FutureStatic.new()
 	future:complete(value)
 	return future
 end
@@ -44,7 +44,7 @@ function FutureStatic.race<T>(futures: { Future<any> })
 		end
 	end
 
-	local future = FutureStatic.raw() :: Future<T>
+	local future = FutureStatic.new() :: Future<T>
 
 	task.spawn(function()
 		local thread = coroutine.running()


### PR DESCRIPTION
This PR has a small name change wherein the `raw` constructor is renamed to `new` to fit more in line w/ the rest of the codebase.