### PR TITLE
Add Future.packCallback

### DIFF
--- a/src/Main/Photo/Flags.luau
+++ b/src/Main/Photo/Flags.luau
@@ -1,19 +1,14 @@
 --!strict
 
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local Future = require(pluginRoot.Utilities.Future)
+
 local Flags = {}
 
 -- Private
 
 local flagsStorage = {}
 local flagsChanged = Instance.new("BindableEvent")
-
-local function packAsCallback<T...>(...: T...): () -> T...
-	local n = select("#", ...)
-	local packed = { select(1, ...) }
-	return function()
-		return unpack(packed, 1, n)
-	end
-end
 
 -- Public
 
@@ -28,7 +23,7 @@ end
 
 function Flags.wrap<T...>(key: string, callback: () -> T...)
 	Flags.set(key, true)
-	local unpackResult = packAsCallback(callback())
+	local unpackResult = Future.packAsCallback(callback())
 	Flags.set(key, false)
 	return unpackResult()
 end

--- a/src/Utilities/Context.luau
+++ b/src/Utilities/Context.luau
@@ -1,5 +1,8 @@
 --!strict
 
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local Future = require(pluginRoot.Utilities.Future)
+
 local ContextClass = {}
 ContextClass.__index = ContextClass
 ContextClass.ClassName = "Context"
@@ -23,14 +26,6 @@ end
 
 -- Private
 
-local function packAsCallback<T...>(...: T...): () -> T...
-	local n = select("#", ...)
-	local packed = { select(1, ...) }
-	return function()
-		return unpack(packed, 1, n)
-	end
-end
-
 local function iterateFunctionStack(level: number)
 	local stack = level
 	return function()
@@ -47,7 +42,7 @@ end
 
 function ContextClass.With<T, U...>(self: Context<T>, value: T, callback: () -> U...)
 	self.map[callback] = value
-	local unpackResult = packAsCallback(callback())
+	local unpackResult = Future.packAsCallback(callback())
 	self.map[callback] = nil
 	return unpackResult()
 end

--- a/src/Utilities/Future.luau
+++ b/src/Utilities/Future.luau
@@ -8,11 +8,9 @@ FutureClass.ClassName = "Future"
 
 export type Future<T> = typeof(setmetatable(
 	{} :: {
-		_typecast: T,
-
-		type: "Pending" | "Completed",
+		type: "pending" | "completed",
 		awaiting: { [thread]: boolean },
-		value: T?,
+		value: T,
 	},
 	FutureClass
 ))
@@ -22,11 +20,9 @@ export type Future<T> = typeof(setmetatable(
 function FutureStatic.new<T>()
 	local self = setmetatable({}, FutureClass) :: Future<T>
 
-	self._typecast = (nil :: any) :: T
-
-	self.type = "Pending"
+	self.type = "pending"
 	self.awaiting = {}
-	self.value = nil
+	self.value = (nil :: any) :: T
 
 	return self
 end
@@ -37,27 +33,31 @@ function FutureStatic.completed<T>(value: T)
 	return future
 end
 
-function FutureStatic.race<T>(futures: { Future<any> })
-	for _, future in futures do
-		if future.type == "Completed" then
-			return future
+function FutureStatic.race<T>(racingFutures: { Future<T> })
+	for _, racingFuture in racingFutures do
+		if racingFuture.type == "completed" then
+			return FutureStatic.completed(racingFuture.value)
 		end
 	end
 
 	local future = FutureStatic.new() :: Future<T>
 
 	task.spawn(function()
+		for _, racingFuture in racingFutures do
+			if racingFuture.type == "completed" then
+				future:complete(racingFuture.value)
+				return
+			end
+		end
+
 		local thread = coroutine.running()
-		for _, racingFuture in futures do
-			assert(racingFuture.type == "Pending", "Cannot race completed future.")
+		for _, racingFuture in racingFutures do
 			racingFuture.awaiting[thread] = true
 		end
 
 		local value = coroutine.yield()
-		for _, racingFuture in futures do
-			if racingFuture.type == "Pending" then
-				racingFuture.awaiting[thread] = nil
-			end
+		for _, racingFuture in racingFutures do
+			racingFuture.awaiting[thread] = nil
 		end
 
 		future:complete(value)
@@ -66,16 +66,25 @@ function FutureStatic.race<T>(futures: { Future<any> })
 	return future
 end
 
+-- Static
+
+function FutureStatic.packAsCallback<T...>(...: T...)
+	local packed = table.pack(...)
+	return function(): T...
+		return table.unpack(packed :: { any }, 1, packed.n)
+	end
+end
+
 -- Public
 
 function FutureClass.isCompleted<T>(self: Future<T>)
-	return self.type == "Completed"
+	return self.type == "completed"
 end
 
 function FutureClass.complete<T>(self: Future<T>, value: T)
-	assert(self.type ~= "Completed", "Cannot complete a future that is already completed")
+	assert(self.type == "pending", "Cannot complete a future that is already completed")
 
-	self.type = "Completed"
+	self.type = "completed"
 	self.value = value
 
 	local awaiting = self.awaiting
@@ -85,14 +94,13 @@ function FutureClass.complete<T>(self: Future<T>, value: T)
 	end
 end
 
-function FutureClass.expect<T>(self: Future<T>): T
-	if self.type == "Completed" then
-		return self.value :: T
+function FutureClass.expect<T>(self: Future<T>)
+	if self.type == "pending" then
+		local thread = coroutine.running()
+		self.awaiting[thread] = true
+		coroutine.yield()
 	end
-
-	local thread = coroutine.running()
-	self.awaiting[thread] = true
-	return coroutine.yield()
+	return self.value
 end
 
 --

--- a/src/Utilities/Parallel/init.luau
+++ b/src/Utilities/Parallel/init.luau
@@ -2,6 +2,9 @@
 
 local RunService = game:GetService("RunService") :: RunService
 
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local Future = require(pluginRoot.Utilities.Future)
+
 -- Class
 
 local ParallelStatic = {}
@@ -92,44 +95,6 @@ function ParallelStatic.new<T..., U...>(n: number, required: Required<T..., U...
 	return self
 end
 
--- Private
-
-local function quickFuture<T>()
-	local result: T
-	local isComplete = false
-	local awaiting: { [thread]: boolean } = {}
-
-	local function complete(value: T)
-		if not isComplete then
-			isComplete = true
-			result = value
-			for thread, _ in awaiting do
-				task.spawn(thread)
-			end
-			awaiting = {}
-		end
-	end
-
-	local function expect()
-		if not isComplete then
-			local thread = coroutine.running()
-			awaiting[thread] = true
-			coroutine.yield()
-		end
-		return result
-	end
-
-	return complete, expect
-end
-
-local function packAsCallback<T...>(...: T...): () -> T...
-	local n = select("#", ...)
-	local packed = { select(1, ...) }
-	return function()
-		return unpack(packed, 1, n)
-	end
-end
-
 -- Public
 
 function ParallelClass.GetActorCount<T..., U...>(self: Parallel<T..., U...>)
@@ -146,7 +111,7 @@ function ParallelClass.Schedule<T..., U...>(self: Parallel<T..., U...>, ...: T..
 	local actorIndex = ((myTicket - 1) % #self.actors) + 1
 	local actor = self.actors[actorIndex]
 
-	table.insert(self.schedules[actor], packAsCallback(...))
+	table.insert(self.schedules[actor], Future.packAsCallback(...))
 end
 
 function ParallelClass.Clear<T..., U...>(self: Parallel<T..., U...>)
@@ -163,18 +128,18 @@ function ParallelClass.Work<T..., U...>(self: Parallel<T..., U...>)
 	assert(not self.isWorking, "Already working!")
 	self.isWorking = true
 
-	local expectations = {}
+	local futures = {}
 	for i, actor in self.actors do
 		local schedule = self.schedules[actor]
 		for j, unpackArgs in schedule do
 			local k = ((j - 1) * #self.actors) + i
-			local complete, expect = quickFuture()
-			expectations[k] = expect
+			local future = Future.new()
+			futures[k] = future
 
 			local connection
 			connection = self.binding.Event:Connect(function(index: number, ...: any)
 				if k == index then
-					complete(packAsCallback(...) :: () -> U...)
+					future:complete(Future.packAsCallback(...) :: () -> U...)
 					connection:Disconnect()
 				end
 			end)
@@ -186,8 +151,9 @@ function ParallelClass.Work<T..., U...>(self: Parallel<T..., U...>)
 	self:Clear()
 
 	local results = {}
-	for i, expect in expectations do
-		results[i] = expect()
+	for i, future in futures do
+		local castedFuture = future :: Future.Future<() -> U...>
+		results[i] = castedFuture:expect()
 	end
 
 	self.isWorking = false

--- a/src/Utilities/TimeIt.luau
+++ b/src/Utilities/TimeIt.luau
@@ -1,16 +1,11 @@
 --!strict
 
-local function packAsCallback<T...>(...: T...): () -> T...
-	local n = select("#", ...)
-	local packed = { select(1, ...) }
-	return function()
-		return unpack(packed, 1, n)
-	end
-end
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local Future = require(pluginRoot.Utilities.Future)
 
 local function timeIt<T...>(callback: () -> T...)
 	local t = os.clock()
-	local unpackResult = packAsCallback(callback())
+	local unpackResult = Future.packAsCallback(callback())
 	local dt = os.clock() - t
 	return dt, unpackResult()
 end


### PR DESCRIPTION
This PR extends the Future module to include `Future.packCallback` which is a helpful function for passing type packed values across different data structures.

Previously this code had been seperate functions in each module it was used in, but now it's in a single centralized location.