### PR TITLE
Support new studio edit image size

### DIFF
--- a/src/Constants.luau
+++ b/src/Constants.luau
@@ -1,11 +1,17 @@
 --!strict
 
+-- lune needs to be able to read this file
+-- so do not use roblox data types
+
 return {
 	ServeEnabled = false,
 	ServePort = 1816, -- Camera invention date!
 
 	ShowFullscreenActionBarButton = true,
-	SplitHighResViewerImages = true,
 
-	DockWidgetSize = { 260, 320 },
+	TileHighResImagesEnabled = true,
+	TileHighResImagesSize = { X = 1024, Y = 1024 },
+	MaxCaptureRectSize = { X = 2048, Y = 2048 },
+
+	DockWidgetSize = { X = 260, Y = 320 },
 }

--- a/src/Main/Photo/Captures/Screenshot.luau
+++ b/src/Main/Photo/Captures/Screenshot.luau
@@ -7,6 +7,7 @@ local pluginRoot = script:FindFirstAncestor("PluginRoot")
 local Context = require(pluginRoot.Utilities.Context)
 local Future = require(pluginRoot.Packages.Future)
 local Image = require(pluginRoot.Utilities.Image)
+local Constants = require(pluginRoot.Constants)
 
 local photoRoot = script:FindFirstAncestor("Photo")
 local Configuration = require(photoRoot.Configuration)
@@ -104,8 +105,8 @@ function Screenshot.rect(rect: Rect)
 		return screenshot()
 	else
 		assert(
-			not (rect.Width > Image.MAX_EDIT_IMAGE_SIZE.X or rect.Height > Image.MAX_EDIT_IMAGE_SIZE.Y),
-			`Capture target is larger than {Image.MAX_EDIT_IMAGE_SIZE.X} x {Image.MAX_EDIT_IMAGE_SIZE.Y}.`
+			not (rect.Width > Constants.MaxCaptureRectSize.X or rect.Height > Constants.MaxCaptureRectSize.Y),
+			`Capture target is larger than {Constants.MaxCaptureRectSize.X} x {Constants.MaxCaptureRectSize.Y}.`
 		)
 
 		return screenshot(rect)

--- a/src/Main/UserInterface/Components/CroppedViewport/init.luau
+++ b/src/Main/UserInterface/Components/CroppedViewport/init.luau
@@ -2,10 +2,11 @@
 
 local pluginRoot = script:FindFirstAncestor("PluginRoot")
 local StudioComponents = require(pluginRoot.Packages.StudioComponents)
-local RenderRect = require(pluginRoot.Utilities.RenderRect)
-local Image = require(pluginRoot.Utilities.Image)
 local React = require(pluginRoot.Packages.React)
 local Sift = require(pluginRoot.Packages.Sift)
+
+local RenderRect = require(pluginRoot.Utilities.RenderRect)
+local Constants = require(pluginRoot.Constants)
 
 local ContainerSize = require(script.Parent.Shared.ContainerSize)
 
@@ -15,6 +16,8 @@ local Blinder = require(script.Blinder)
 
 local uiRoot = script:FindFirstAncestor("UserInterface")
 local Hooks = require(uiRoot.Hooks)
+
+local MAX_CAPTURE_RECT_SIZE = Vector2.new(Constants.MaxCaptureRectSize.X, Constants.MaxCaptureRectSize.Y)
 
 local GRABBERS = {
 	CornersEnabled = true,
@@ -37,8 +40,6 @@ local ACTION_BAR = {
 	Padding = 8,
 }
 
-local MAX_EDIT_IMAGE_SIZE = Image.MAX_EDIT_IMAGE_SIZE
-
 local grabberMargin = GRABBERS.Padding + GRABBERS.Thickness
 local actionBarPadding = if GRABBERS.MiddlesEnabled
 	then ACTION_BAR.Padding + grabberMargin
@@ -60,8 +61,8 @@ local function useLenseSize(size: Vector2, viewportSize: Vector2, scale: Vector2
 	local minX = math.max(0, math.min(width, grabberMin * scale.X))
 	local minY = math.max(0, math.min(height, grabberMin * scale.Y))
 
-	local maxX = math.min(MAX_EDIT_IMAGE_SIZE.X * scale.X, width)
-	local maxY = math.min(MAX_EDIT_IMAGE_SIZE.Y * scale.Y, height)
+	local maxX = math.min(MAX_CAPTURE_RECT_SIZE.X * scale.X, width)
+	local maxY = math.min(MAX_CAPTURE_RECT_SIZE.Y * scale.Y, height)
 
 	local clampedX = math.clamp(size.X * scale.X, minX, math.max(minX, maxX))
 	local clampedY = math.clamp(size.Y * scale.X, minY, math.max(minY, maxY))
@@ -78,9 +79,9 @@ local function CroppedViewport(props: Props & { ViewportSize: Vector2 })
 
 	local aspectKeysDown, setAspectKeysDown = React.useState({})
 
-	local size, setSize = React.useState(MAX_EDIT_IMAGE_SIZE / 2)
+	local size, setSize = React.useState(MAX_CAPTURE_RECT_SIZE / 2)
 	local sizeInitiated = React.useRef(false)
-	local prevSize = React.useRef(MAX_EDIT_IMAGE_SIZE / 2)
+	local prevSize = React.useRef(MAX_CAPTURE_RECT_SIZE / 2)
 	local startDrag = React.useRef(nil :: Vector3?)
 
 	local actionBarWidth = if props.OnMaximize then 148 else 120

--- a/src/Main/UserInterface/Components/Gallery/ImageViewer/HighResImageSplit.luau
+++ b/src/Main/UserInterface/Components/Gallery/ImageViewer/HighResImageSplit.luau
@@ -6,10 +6,6 @@ local pluginRoot = script:FindFirstAncestor("PluginRoot")
 local React = require(pluginRoot.Packages.React)
 
 local Constants = require(pluginRoot.Constants)
-local Image = require(pluginRoot.Utilities.Image)
-
-local MAX_EDIT_IMAGE_WIDTH = Image.MAX_EDIT_IMAGE_SIZE.X
-local MAX_EDIT_IMAGE_HEIGHT = Image.MAX_EDIT_IMAGE_SIZE.Y
 
 export type Props = {
 	Size: UDim2,
@@ -31,18 +27,22 @@ local function useHighResSplit(sourceEditableImage: EditableImage)
 		local sourceWidth = sourceEditableImage.Size.X
 		local sourceHeight = sourceEditableImage.Size.Y
 
-		local dx = math.ceil(sourceWidth / MAX_EDIT_IMAGE_WIDTH)
-		local dy = math.ceil(sourceHeight / MAX_EDIT_IMAGE_HEIGHT)
+		local dx = math.ceil(sourceWidth / Constants.TileHighResImagesSize.X)
+		local dy = math.ceil(sourceHeight / Constants.TileHighResImagesSize.Y)
 
 		if dx > 1 or dy > 1 then
 			local newSplit = {}
 			local thread = task.spawn(function()
 				for x = 1, dx do
 					for y = 1, dy do
-						local offset = Vector2.new((x - 1) * MAX_EDIT_IMAGE_WIDTH, (y - 1) * MAX_EDIT_IMAGE_HEIGHT)
+						local offset = Vector2.new(
+							(x - 1) * Constants.TileHighResImagesSize.X,
+							(y - 1) * Constants.TileHighResImagesSize.Y
+						)
+
 						local size = Vector2.new(
-							math.min(MAX_EDIT_IMAGE_WIDTH, sourceWidth - offset.X),
-							math.min(MAX_EDIT_IMAGE_HEIGHT, sourceHeight - offset.Y)
+							math.min(Constants.TileHighResImagesSize.X, sourceWidth - offset.X),
+							math.min(Constants.TileHighResImagesSize.Y, sourceHeight - offset.Y)
 						)
 
 						local chunkBuffer = sourceEditableImage:ReadPixelsBuffer(offset, size)
@@ -80,7 +80,7 @@ end
 
 local function HighResImageSplit(props: Props)
 	local split
-	if Constants.SplitHighResViewerImages then
+	if Constants.TileHighResImagesEnabled then
 		split = useHighResSplit(props.EditableImage)
 	else
 		split = React.useMemo(function()

--- a/src/Main/UserInterface/Components/Gallery/init.luau
+++ b/src/Main/UserInterface/Components/Gallery/init.luau
@@ -39,8 +39,8 @@ local function WindowContainer(props: WindowContainerProps)
 		BorderColor3 = theme:GetColor(Enum.StudioStyleGuideColor.Border),
 	}, {
 		UISizeConstraint = React.createElement("UISizeConstraint", {
-			MinSize = Vector2.new(Constants.DockWidgetSize[1] - 20, Constants.DockWidgetSize[2] - 20),
-			MaxSize = Vector2.new((Constants.DockWidgetSize[1] - 20) * 2, (Constants.DockWidgetSize[2] - 20) * 2),
+			MinSize = Vector2.new(Constants.DockWidgetSize.X - 20, Constants.DockWidgetSize.Y - 20),
+			MaxSize = Vector2.new((Constants.DockWidgetSize.X - 20) * 2, (Constants.DockWidgetSize.Y - 20) * 2),
 		}),
 	}, props.children)
 end

--- a/src/Main/UserInterface/Stories/Gallery.story.luau
+++ b/src/Main/UserInterface/Stories/Gallery.story.luau
@@ -49,7 +49,7 @@ local function story()
 		["Small"] = {
 			LayoutOrder = 1,
 			Content = React.createElement(Widget, {
-				Size = UDim2.fromOffset(Constants.DockWidgetSize[1], Constants.DockWidgetSize[2]),
+				Size = UDim2.fromOffset(Constants.DockWidgetSize.X, Constants.DockWidgetSize.Y),
 			}),
 		},
 		["Medium"] = {

--- a/src/Main/UserInterface/init.luau
+++ b/src/Main/UserInterface/init.luau
@@ -236,10 +236,10 @@ function UserInterface.mountGallery(plugin: Plugin, toolbar: PluginToolbar)
 		Enum.InitialDockState.Float, -- Widget will be initialized in floating panel
 		false, -- Widget will be initially enabled
 		false, -- Don't override the previous enabled state
-		Constants.DockWidgetSize[1], -- Default width of the floating window
-		Constants.DockWidgetSize[2], -- Default height of the floating window
-		Constants.DockWidgetSize[1], -- Minimum width of the floating window
-		Constants.DockWidgetSize[2] -- Minimum height of the floating window
+		Constants.DockWidgetSize.X, -- Default width of the floating window
+		Constants.DockWidgetSize.Y, -- Default height of the floating window
+		Constants.DockWidgetSize.X, -- Minimum width of the floating window
+		Constants.DockWidgetSize.Y -- Minimum height of the floating window
 	)
 
 	local dock = plugin:CreateDockWidgetPluginGui("PhotoboothViewer", info)

--- a/src/Utilities/Image.luau
+++ b/src/Utilities/Image.luau
@@ -17,9 +17,9 @@ export type Image = typeof(setmetatable(
 
 -- CONSTANTS
 
-local MAX_EDIT_IMAGE_SIZE = Vector2.new(1024, 1024)
-local MAX_EDIT_IMAGE_WIDTH = MAX_EDIT_IMAGE_SIZE.X
-local MAX_EDIT_IMAGE_HEIGHT = MAX_EDIT_IMAGE_SIZE.Y
+local MAX_READ_WRITE_IMAGE_SIZE = Vector2.new(1024, 1024)
+local MAX_READ_WRITE_IMAGE_WIDTH = MAX_READ_WRITE_IMAGE_SIZE.X
+local MAX_READ_WRITE_IMAGE_HEIGHT = MAX_READ_WRITE_IMAGE_SIZE.Y
 
 local NEIGHBOR_OFFSETS: { { number } } = {
 	{ -1, -1 },
@@ -31,8 +31,6 @@ local NEIGHBOR_OFFSETS: { { number } } = {
 	{ 0, 1 },
 	{ 1, 1 },
 }
-
-ImageClass.MAX_EDIT_IMAGE_SIZE = MAX_EDIT_IMAGE_SIZE
 
 -- Constructors
 
@@ -54,21 +52,21 @@ function ImageClass.fromEditableImage(editableImage: EditableImage, crop: Rect?)
 	local origin = if crop then crop.Min:Min(fullSize) else Vector2.zero
 	local cropSize = if crop then (crop.Max - crop.Min):Min(fullSize) else fullSize
 
-	if cropSize.X > MAX_EDIT_IMAGE_WIDTH or cropSize.Y > MAX_EDIT_IMAGE_HEIGHT then
-		-- if the input editable image is larger than MAX_EDIT_IMAGE_SIZE then we get an error when trying to read the pixel buffer
+	if cropSize.X > MAX_READ_WRITE_IMAGE_WIDTH or cropSize.Y > MAX_READ_WRITE_IMAGE_HEIGHT then
+		-- if the input editable image is larger than MAX_READ_WRITE_IMAGE_SIZE then we get an error when trying to read the pixel buffer
 		-- as a result we need to read the buffer in chunks and then put it together again into its full size (very cool, thanks Roblox)
 
 		local resultBuffer = buffer.create(cropSize.X * cropSize.Y * 4)
 
-		local dx = math.ceil(cropSize.X / MAX_EDIT_IMAGE_WIDTH)
-		local dy = math.ceil(cropSize.Y / MAX_EDIT_IMAGE_HEIGHT)
+		local dx = math.ceil(cropSize.X / MAX_READ_WRITE_IMAGE_WIDTH)
+		local dy = math.ceil(cropSize.Y / MAX_READ_WRITE_IMAGE_HEIGHT)
 
 		for x = 1, dx do
 			for y = 1, dy do
-				local offset = Vector2.new((x - 1) * MAX_EDIT_IMAGE_WIDTH, (y - 1) * MAX_EDIT_IMAGE_HEIGHT)
+				local offset = Vector2.new((x - 1) * MAX_READ_WRITE_IMAGE_WIDTH, (y - 1) * MAX_READ_WRITE_IMAGE_HEIGHT)
 				local size = Vector2.new(
-					math.min(MAX_EDIT_IMAGE_WIDTH, cropSize.X - offset.X),
-					math.min(MAX_EDIT_IMAGE_HEIGHT, cropSize.Y - offset.Y)
+					math.min(MAX_READ_WRITE_IMAGE_WIDTH, cropSize.X - offset.X),
+					math.min(MAX_READ_WRITE_IMAGE_HEIGHT, cropSize.Y - offset.Y)
 				)
 
 				local chunkBuffer = editableImage:ReadPixelsBuffer(origin + offset, size)
@@ -208,15 +206,15 @@ end
 function ImageClass.WriteToEditableImage(self: Image, editableImage: EditableImage, position: Vector2, size: Vector2)
 	size = (position + size):Max(editableImage.Size) - position
 
-	local dx = math.ceil(size.X / MAX_EDIT_IMAGE_WIDTH)
-	local dy = math.ceil(size.Y / MAX_EDIT_IMAGE_HEIGHT)
+	local dx = math.ceil(size.X / MAX_READ_WRITE_IMAGE_WIDTH)
+	local dy = math.ceil(size.Y / MAX_READ_WRITE_IMAGE_HEIGHT)
 
 	for x = 1, dx do
 		for y = 1, dy do
-			local offset = Vector2.new((x - 1) * MAX_EDIT_IMAGE_WIDTH, (y - 1) * MAX_EDIT_IMAGE_HEIGHT)
+			local offset = Vector2.new((x - 1) * MAX_READ_WRITE_IMAGE_WIDTH, (y - 1) * MAX_READ_WRITE_IMAGE_HEIGHT)
 			local cropSize = Vector2.new(
-				math.min(MAX_EDIT_IMAGE_WIDTH, size.X - offset.X),
-				math.min(MAX_EDIT_IMAGE_HEIGHT, size.Y - offset.Y)
+				math.min(MAX_READ_WRITE_IMAGE_WIDTH, size.X - offset.X),
+				math.min(MAX_READ_WRITE_IMAGE_HEIGHT, size.Y - offset.Y)
 			)
 			local cropImage = self:Crop(Rect.new(offset, offset + cropSize))
 			editableImage:WritePixelsBuffer(position + offset, cropSize, cropImage.buffer)
@@ -279,11 +277,11 @@ function ImageClass.Save(self: Image)
 
 	local editableImage = AssetService:CreateEditableImage({
 		Size = self.size,
-	})
+	}) :: EditableImage
 
-	editableImage:WritePixelsBuffer(Vector2.zero, self.size, self.buffer)
+	self:WriteToEditableImage(editableImage, Vector2.zero, self.size)
 
-	return editableImage :: EditableImage
+	return editableImage
 end
 
 function ImageClass.Destroy(_self: Image) end


### PR DESCRIPTION
This PR changes the max rect that can be crop captured.

A few new constants were added to handle this, but the important thing to consider is that `ReadPixelsBuffer` and `WritePixelsBuffer` methods still enforce a `1024 x 1024` limit.