### PR TITLE
Add error text stroke

### DIFF
--- a/src/Main/UserInterface/Components/CroppedViewport/ActionBar.luau
+++ b/src/Main/UserInterface/Components/CroppedViewport/ActionBar.luau
@@ -235,15 +235,23 @@ local function ActionBar(props: Props)
 			}),
 		}),
 
-		ErrorLabel = errorOffset.Z < 1 and React.createElement(StudioComponents.Label, {
+		ErrorLabel = errorOffset.Z < 1 and React.createElement("TextLabel", {
 			BackgroundTransparency = 1,
 			Position = if useUnderFrame then UDim2.new(0, 0, 1, 2) else UDim2.new(1, 8, 0, 0),
 			Size = UDim2.fromScale(1, 1),
+			FontFace = Font.fromName("SourceSans", Enum.FontWeight.Bold, Enum.FontStyle.Normal),
 			Text = "Error: Check the output.",
+			TextSize = 14,
 			TextTransparency = errorOffset.Z ^ 20,
-			TextColorStyle = Enum.StudioStyleGuideColor.ErrorText,
+			TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.ErrorText),
 			TextXAlignment = if useUnderFrame then Enum.TextXAlignment.Center else Enum.TextXAlignment.Left,
 			TextYAlignment = if useUnderFrame then Enum.TextYAlignment.Top else Enum.TextYAlignment.Center,
+		}, {
+			UIStroke = React.createElement("UIStroke", {
+				Thickness = 1,
+				Transparency = errorOffset.Z ^ 20,
+				Color = Color3.new(0, 0, 0),
+			}),
 		}),
 		UnderFrame = React.createElement("Frame", {
 			BackgroundTransparency = 1,

--- a/src/Main/UserInterface/Components/FullViewport/init.luau
+++ b/src/Main/UserInterface/Components/FullViewport/init.luau
@@ -188,15 +188,23 @@ local function ActionBar(props: ActionBarProps)
 			}),
 		}),
 
-		ErrorLabel = errorOffset.Z < 1 and React.createElement(StudioComponents.Label, {
+		ErrorLabel = errorOffset.Z < 1 and React.createElement("TextLabel", {
 			BackgroundTransparency = 1,
 			Position = if useUnderFrame then UDim2.new(0, 0, 1, 2) else UDim2.new(0, 0, -1, -2),
 			Size = UDim2.fromScale(1, 1),
+			FontFace = Font.fromName("SourceSans", Enum.FontWeight.Bold, Enum.FontStyle.Normal),
 			Text = "Error: Check the output.",
+			TextSize = 14,
 			TextTransparency = errorOffset.Z ^ 20,
-			TextColorStyle = Enum.StudioStyleGuideColor.ErrorText,
+			TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.ErrorText),
 			TextXAlignment = Enum.TextXAlignment.Center,
 			TextYAlignment = if useUnderFrame then Enum.TextYAlignment.Top else Enum.TextYAlignment.Bottom,
+		}, {
+			UIStroke = React.createElement("UIStroke", {
+				Thickness = 1,
+				Transparency = errorOffset.Z ^ 20,
+				Color = Color3.new(0, 0, 0),
+			}),
 		}),
 		UnderFrame = React.createElement("Frame", {
 			BackgroundTransparency = 1,

--- a/src/Main/UserInterface/Stories/Helpers/CreateStory/init.luau
+++ b/src/Main/UserInterface/Stories/Helpers/CreateStory/init.luau
@@ -181,7 +181,31 @@ local function createFlipbookStory(component: React.FC<any>)
 	end
 end
 
+local function createThemeStory(theme: "dark" | "light", component: React.FC<any>)
+	return function(props: any)
+		return React.createElement(IsStoryContext.Provider, {
+			value = true,
+		}, {
+			PluginProvider = React.createElement(StudioComponents.PluginProvider, {
+				Plugin = GetStoryPlugin(),
+			}, {
+				ThemeProvider = React.createElement(StudioComponents.ThemeContext.Provider, {
+					value = if theme == "dark" then themes[1] else themes[2],
+				}, {
+					Container = React.createElement("Frame", {
+						BackgroundTransparency = 1,
+						Size = UDim2.fromScale(1, 1),
+					}, {
+						Component = React.createElement(component, props),
+					}),
+				}),
+			}),
+		})
+	end
+end
+
 return {
 	split = createSplitThemeStory,
 	flipbook = createFlipbookStory,
+	theme = createThemeStory,
 }


### PR DESCRIPTION
This PR adds a stroke and makes the text bold around the error label that appears when something goes wrong with the fullscreen or cropped view capture process.

This was done to make it easier to read the text against low constrast backgrounds in the viewport.