### PR TITLE
Add update notification

### DIFF
--- a/src/Builds/Plugin.luau
+++ b/src/Builds/Plugin.luau
@@ -6,7 +6,6 @@ local pluginRoot = script:FindFirstAncestor("PluginRoot")
 local Screenshot = require(pluginRoot.Main.Photo.Captures.Screenshot)
 local UserInterface = require(pluginRoot.Main.UserInterface)
 local Bindings = require(pluginRoot.Main.Bindings)
-local Photo = require(pluginRoot.Main.Photo)
 local State = require(pluginRoot.Main.State)
 
 local Plugin = {}

--- a/src/Main/UserInterface/Components/Gallery/ConfigurationWindow/init.luau
+++ b/src/Main/UserInterface/Components/Gallery/ConfigurationWindow/init.luau
@@ -234,10 +234,16 @@ end
 
 local function ConfigurationWindow(props: Props)
 	local theme = StudioComponents.useTheme()
+	local latestVersion = Hooks.useLatestVersion()
 	local isLocalPlugin = Hooks.useIsLocalPlugin()
 
 	local state = Hooks.useState()
 	local mutateState = React.useCallback(State.mutate, {})
+
+	local versionText = `v{Wally.package.version}-{if isLocalPlugin then "local" else "cloud"}`
+	if latestVersion ~= Wally.package.version then
+		versionText = "update available*\n" .. versionText
+	end
 
 	return React.createElement("Frame", {
 		AnchorPoint = props.AnchorPoint,
@@ -318,11 +324,12 @@ local function ConfigurationWindow(props: Props)
 			AnchorPoint = Vector2.new(0, 1),
 			Position = UDim2.fromScale(0, 1),
 			Size = UDim2.fromOffset(80, 28),
-			Text = `v{Wally.package.version}-{if isLocalPlugin then "local" else "cloud"}`,
+			Text = versionText,
 			TextSize = 6,
 			TextXAlignment = Enum.TextXAlignment.Left,
 			TextYAlignment = Enum.TextYAlignment.Bottom,
 			Disabled = true,
+			ZIndex = -1,
 		}, {
 			Padding = React.createElement("UIPadding", {
 				PaddingLeft = UDim.new(0, 2),

--- a/src/Main/UserInterface/Hooks/Photobooth/useLatestVersion.luau
+++ b/src/Main/UserInterface/Hooks/Photobooth/useLatestVersion.luau
@@ -1,0 +1,39 @@
+--!strict
+
+local MarketplaceService = game:GetService("MarketplaceService") :: MarketplaceService
+
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local Signal = require(pluginRoot.Packages.Signal)
+local React = require(pluginRoot.Packages.React)
+local Wally = require(pluginRoot.Wally)
+
+local finished = Signal.new()
+local resultVersion = Wally.package.version
+
+task.spawn(function()
+	local success, result =
+		pcall(MarketplaceService.GetProductInfo, MarketplaceService, 87864471469006, Enum.InfoType.Asset)
+	if success then
+		resultVersion = result.Description
+		finished:Fire()
+	end
+end)
+
+local function useLatestVersion()
+	local latestVersion, setLatestVersion = React.useState(resultVersion)
+
+	React.useEffect(function()
+		setLatestVersion(resultVersion)
+		local connection = finished:Connect(function()
+			setLatestVersion(resultVersion)
+		end)
+
+		return function()
+			connection:Disconnect()
+		end
+	end, {})
+
+	return latestVersion
+end
+
+return useLatestVersion

--- a/src/Main/UserInterface/Hooks/Plugin/useHasCreateAssetPermission.luau
+++ b/src/Main/UserInterface/Hooks/Plugin/useHasCreateAssetPermission.luau
@@ -29,7 +29,7 @@ local function useHasCreateAssetPermission()
 		return function()
 			connection:Disconnect()
 		end
-	end)
+	end, {})
 
 	return hasPermission
 end

--- a/src/Main/UserInterface/Hooks/init.luau
+++ b/src/Main/UserInterface/Hooks/init.luau
@@ -22,6 +22,7 @@ local useHasCreateAssetPermission = require(script.Plugin.useHasCreateAssetPermi
 -- Photobooth specific
 local useState = require(script.Photobooth.useState)
 local useStatePath = require(script.Photobooth.useStatePath)
+local useLatestVersion = require(script.Photobooth.useLatestVersion)
 local useEditableImageInfos = require(script.Photobooth.useEditableImageInfos)
 
 export type EditableImageInfo = useEditableImageInfos.EditableImageInfo
@@ -47,5 +48,6 @@ return {
 
 	useState = useState,
 	useStatePath = useStatePath,
+	useLatestVersion = useLatestVersion,
 	useEditableImageInfos = useEditableImageInfos,
 }


### PR DESCRIPTION
This PR adds notification text to the displayed semver to let a user know if there's a more recent version of photobooth available. This feature is typically more useful for itch users since if you installed from the creator store you'll be able to see available updates right from the menu.