### PR TITLE
Add semver package

### DIFF
--- a/src/Main/UserInterface/Components/Gallery/ConfigurationWindow/init.luau
+++ b/src/Main/UserInterface/Components/Gallery/ConfigurationWindow/init.luau
@@ -2,6 +2,7 @@
 
 local pluginRoot = script:FindFirstAncestor("PluginRoot")
 local StudioComponents = require(pluginRoot.Packages.StudioComponents)
+local Semver = require(pluginRoot.Packages.Semver)
 local Lucide = require(pluginRoot.Packages.Lucide)
 local React = require(pluginRoot.Packages.React)
 local Wally = require(pluginRoot.Wally)
@@ -272,7 +273,7 @@ local function ConfigurationWindow(props: Props)
 	local mutateState = React.useCallback(State.mutate, {})
 
 	local versionText = `v{Wally.package.version}-{if isLocalPlugin then "local" else "cloud"}`
-	if latestVersion ~= Wally.package.version then
+	if Semver.validateVersion(Wally.package.version) and Semver.cmp(latestVersion, ">", Wally.package.version) then
 		versionText = "update available*\n" .. versionText
 	end
 

--- a/src/Main/UserInterface/Hooks/Photobooth/useLatestVersion.luau
+++ b/src/Main/UserInterface/Hooks/Photobooth/useLatestVersion.luau
@@ -3,19 +3,21 @@
 local MarketplaceService = game:GetService("MarketplaceService") :: MarketplaceService
 
 local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local Semver = require(pluginRoot.Packages.Semver)
 local Signal = require(pluginRoot.Packages.Signal)
 local React = require(pluginRoot.Packages.React)
-local Wally = require(pluginRoot.Wally)
 
 local finished = Signal.new()
-local resultVersion = Wally.package.version
+local resultVersion = "0.0.0"
 
 task.spawn(function()
 	local success, result =
 		pcall(MarketplaceService.GetProductInfo, MarketplaceService, 87864471469006, Enum.InfoType.Asset)
 	if success then
-		resultVersion = result.Description
-		finished:Fire()
+		if Semver.validateVersion(result.Description) then
+			resultVersion = result.Description
+			finished:Fire()
+		end
 	end
 end)
 

--- a/wally.lock
+++ b/wally.lock
@@ -20,7 +20,7 @@ dependencies = []
 [[package]]
 name = "egomoose/photobooth-plugin"
 version = "0.9.0"
-dependencies = [["Future", "egomoose/future@1.0.0"], ["GreenTea", "corecii/greentea@0.4.11"], ["Lucide", "virtualbutfake/lucide-roblox@1.1.3"], ["React", "jsdotlua/react@17.2.1"], ["ReactRoblox", "jsdotlua/react-roblox@17.2.1"], ["Ripple", "littensy/ripple@0.9.3"], ["Sift", "csqrl/sift@0.0.11"], ["Signal", "sleitnick/signal@2.0.3"], ["StudioComponents", "sircfenner/studiocomponents@1.2.0"], ["Trove", "sleitnick/trove@1.5.1"]]
+dependencies = [["Future", "egomoose/future@1.0.0"], ["GreenTea", "corecii/greentea@0.4.11"], ["Lucide", "virtualbutfake/lucide-roblox@1.1.3"], ["React", "jsdotlua/react@17.2.1"], ["ReactRoblox", "jsdotlua/react-roblox@17.2.1"], ["Ripple", "littensy/ripple@0.9.3"], ["Semver", "tim7775/semver@1.0.0"], ["Sift", "csqrl/sift@0.0.11"], ["Signal", "sleitnick/signal@2.0.3"], ["StudioComponents", "sircfenner/studiocomponents@1.2.0"], ["Trove", "sleitnick/trove@1.5.1"]]
 
 [[package]]
 name = "evaera/promise"
@@ -131,6 +131,16 @@ dependencies = []
 name = "sleitnick/trove"
 version = "1.5.1"
 dependencies = []
+
+[[package]]
+name = "tim7775/cargo-semver"
+version = "1.0.20"
+dependencies = []
+
+[[package]]
+name = "tim7775/semver"
+version = "1.0.0"
+dependencies = [["CargoSemver", "tim7775/cargo-semver@1.0.20"]]
 
 [[package]]
 name = "virtualbutfake/lucide-roblox"

--- a/wally.toml
+++ b/wally.toml
@@ -10,6 +10,7 @@ Sift = "csqrl/sift@0.0.11"
 Trove = "sleitnick/trove@1.5.1"
 Future = "egomoose/future@1.0.0"
 Signal = "sleitnick/signal@2.0.3"
+Semver = "tim7775/semver@1.0.0"
 GreenTea = "corecii/greentea@0.4.11"
 
 React = "jsdotlua/react@17.2.1"


### PR DESCRIPTION
This PR adds and uses a semver package for plugin version comparison. The old method was technically fine, but this is a bit more flexible for any weird semver in the future.