### PR TITLE
Adjust grayscale calculation

### DIFF
--- a/src/Main/Photo/Captures/Composers/Parallel/ReverseBlend/Worker.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/ReverseBlend/Worker.luau
@@ -74,7 +74,7 @@ local function workerAction(
 			local color = Color3.new(rgba[1], rgba[2], rgba[3])
 			local hue, _saturation, value = color:ToHSV()
 			local grayColor = Color3.fromHSV(hue, 0, value)
-			local gray = grayColor.R
+			local gray = math.max(grayColor.R, grayColor.G, grayColor.B)
 
 			for i = 1, 3 do
 				local component = rgba[i]

--- a/src/Main/Photo/Captures/Composers/Serial/ReverseBlend.luau
+++ b/src/Main/Photo/Captures/Composers/Serial/ReverseBlend.luau
@@ -70,7 +70,7 @@ local function reverseBlendSerial(
 			local color = Color3.new(rgba[1], rgba[2], rgba[3])
 			local hue, _saturation, value = color:ToHSV()
 			local grayColor = Color3.fromHSV(hue, 0, value)
-			local gray = grayColor.R
+			local gray = math.max(grayColor.R, grayColor.G, grayColor.B)
 
 			for i = 1, 3 do
 				local component = rgba[i]


### PR DESCRIPTION
This PR changes the grayscale calulation to take advantage of Roblox's built in HSV functions. I previously had numeric weights, but I'm not sure if these exactly match the roblox engine.