### PR TITLE
Add lighting transfer command

### DIFF
--- a/src/Builds/Plugin.luau
+++ b/src/Builds/Plugin.luau
@@ -3,7 +3,6 @@
 local RunService = game:GetService("RunService") :: RunService
 
 local pluginRoot = script:FindFirstAncestor("PluginRoot")
-local LightingTransfer = require(pluginRoot.Utilities.LightingTransfer)
 local StudioMode = require(pluginRoot.Utilities.StudioMode)
 local Constants = require(pluginRoot.Constants)
 local State = require(pluginRoot.Main.State)
@@ -86,10 +85,6 @@ function Plugin.build(plugin: Plugin)
 	UserInterface.mountGallery(plugin, toolbar)
 
 	Bindings.setup(plugin)
-
-	local lightingTransferBinds = LightingTransfer.bindable(plugin)
-	_G.saveLighting = lightingTransferBinds.save
-	_G.loadLighting = lightingTransferBinds.load
 end
 
 return Plugin

--- a/src/Main/State/init.luau
+++ b/src/Main/State/init.luau
@@ -17,6 +17,7 @@ local stateChanged = Signal.new()
 
 local function defaultTemporary()
 	return {
+		plugin = (nil :: any) :: Plugin,
 		scaleOS = Vector2.one,
 
 		isCapturing = false,
@@ -127,6 +128,8 @@ function State.setup(plugin: Plugin)
 	if not success then
 		initState(nil)
 	end
+
+	currentState.temporary.plugin = plugin
 
 	plugin.Unloading:Connect(function()
 		local saved = SaveVersions.save(currentState.saved)

--- a/src/Utilities/LightingTransfer.luau
+++ b/src/Utilities/LightingTransfer.luau
@@ -6,7 +6,7 @@ local ReflectionService = game:GetService("ReflectionService") :: ReflectionServ
 local SerializationService = game:GetService("SerializationService") :: SerializationService
 
 local VERSION = 1
-local ROOT_KEY = "LightingTransfer"
+local SETTING_KEY = "Photobooth_LightingTransfer"
 
 local LightingTransfer = {}
 
@@ -22,7 +22,7 @@ type Content = {
 }
 
 local function read(plugin: Plugin)
-	local root = plugin:GetSetting(ROOT_KEY)
+	local root = plugin:GetSetting(SETTING_KEY)
 	local success = pcall(function()
 		assert(root.version >= VERSION)
 	end)
@@ -43,7 +43,7 @@ end
 local function mutate(plugin: Plugin, mutation: (Content) -> ())
 	local content = read(plugin).content
 	mutation(content)
-	return plugin:SetSetting(ROOT_KEY, {
+	return plugin:SetSetting(SETTING_KEY, {
 		version = VERSION,
 		content = content,
 	})
@@ -168,32 +168,7 @@ function LightingTransfer.load(plugin: Plugin, key: string?)
 	if lightingSave then
 		setLightingFromSave(lightingSave)
 	end
-end
-
-function LightingTransfer.bindable(plugin: Plugin)
-	-- this is a bit weird, but we have to interface through a bindable instance
-	-- to ensure we have access to the plugin instance which is needed for saving
-
-	local binding = Instance.new("BindableFunction")
-	binding.Name = "Binding"
-	binding.Parent = script
-
-	binding.OnInvoke = function(name: string, key: string?)
-		if name == "save" then
-			return LightingTransfer.save(plugin, key)
-		elseif name == "load" then
-			return LightingTransfer.load(plugin, key)
-		end
-	end
-
-	return {
-		save = function(key: string?)
-			binding:Invoke("save", key)
-		end,
-		load = function(key: string?)
-			binding:Invoke("load", key)
-		end,
-	}
+	return not not lightingSave
 end
 
 --


### PR DESCRIPTION
This PR adds two `_G` commands that can be used to quickly save and load lighting settings between placefiles. This tends to be helpful when you want to pull an item into another scene to take a capture of it in a team create setting etc.