### PR TITLE
Simplify background distance calculation

### DIFF
--- a/src/Main/Photo/Tools/Background/MeshPartFogBackground.luau
+++ b/src/Main/Photo/Tools/Background/MeshPartFogBackground.luau
@@ -49,51 +49,12 @@ end
 
 -- Private
 
-local function getCorners(cframe: CFrame, size2: Vector3)
-	local corners = {}
-	for i = 0, 7 do
-		-- stylua: ignore
-		corners[i + 1] = cframe * (size2 * Vector3.new(
-			2 * (math.floor(i / 4) % 2) - 1,
-			2 * (math.floor(i / 2) % 2) - 1,
-			2 * (i % 2) - 1
-		))
-	end
-	return corners
-end
-
 local function getBoundsIntersection(cameraCF: CFrame)
-	local sceneCF: CFrame, sceneSize: Vector3 = workspace:GetBoundingBox()
-
-	local terrainRegion16 = workspace.Terrain.MaxExtents
-	local terrainRegion = Region3.new(
-		Vector3.new(terrainRegion16.Min.X, terrainRegion16.Min.Y, terrainRegion16.Min.Z),
-		Vector3.new(terrainRegion16.Max.X, terrainRegion16.Max.Y, terrainRegion16.Max.Z)
-	)
-
-	-- stylua: ignore
-	local iterable = { 
-		{ CFrame = sceneCF, Size = sceneSize },
-		{ CFrame = terrainRegion.CFrame, Size = terrainRegion.Size } 
-	}
-
-	local maxCorner: Vector3
-	local cameraPos = cameraCF.Position
-	local lookVector = -cameraCF.ZVector
-
-	local maxDist = -math.huge
-	for _, target in iterable do
-		for _, corner in getCorners(target.CFrame, target.Size / 2) do
-			local dist = (corner - cameraPos):Dot(lookVector)
-			if dist > maxDist then
-				maxCorner = corner
-				maxDist = dist
-			end
-		end
-	end
-
-	local radius = (maxCorner - cameraPos).Magnitude
-	return cameraPos + lookVector * (radius + MARGIN_OF_ERROR_DISTANCE * 2)
+	-- the logic here used to be much more complex
+	-- originally, we'd try and calculate this based on the existing geometry relative to the camera
+	-- however, it's much more consistent to pick a fixed distance that renders on all quality levels
+	-- technically this means you can't capture things more than 90k studs away, but is that really an issue?
+	return cameraCF * Vector3.new(0, 0, -90_000)
 end
 
 function MeshPartFogBackgroundClass._createInstances(_self: MeshPartFogBackground)


### PR DESCRIPTION
The logic here used to be much more complex. Originally, we'd try and calculate this based on the existing geometry relative to the camera. However, it's much more consistent to pick a fixed distance that renders on all quality levels. Technically this means you can't capture things more than 90k studs away, but is that really an issue?