### PR TITLE
Add better error msg

### DIFF
--- a/src/Main/UserInterface/Components/CroppedViewport/ActionBar.luau
+++ b/src/Main/UserInterface/Components/CroppedViewport/ActionBar.luau
@@ -14,6 +14,9 @@ type Props = {
 	Position: UDim2,
 	Size: UDim2,
 
+	ViewportSize: Vector2,
+	ViewportPosition: Vector2,
+
 	DisplayedAbsSize: Vector2,
 	OnDimensionInput: (Vector2) -> (),
 
@@ -128,7 +131,7 @@ local function ActionBar(props: Props)
 	local underFrameAbsPosition = Hooks.useRefProperty(underFrameRef, "AbsolutePosition", Vector2.zero)
 	local underFrameAbsSize = Hooks.useRefProperty(underFrameRef, "AbsoluteSize", Vector2.zero)
 	local underFrameBottomY = underFrameAbsPosition.Y + underFrameAbsSize.Y
-	local useUnderFrame = underFrameBottomY <= workspace.CurrentCamera.ViewportSize.Y
+	local useUnderFrame = underFrameBottomY <= (props.ViewportPosition.Y + props.ViewportSize.Y)
 
 	local shakeOffset, makeShake = Hooks.useShake()
 	local errorOffset, makeError = Hooks.useShake()
@@ -240,11 +243,12 @@ local function ActionBar(props: Props)
 			Position = if useUnderFrame then UDim2.new(0, 0, 1, 2) else UDim2.new(1, 8, 0, 0),
 			Size = UDim2.fromScale(1, 1),
 			FontFace = Font.fromName("SourceSansPro", Enum.FontWeight.Bold, Enum.FontStyle.Normal),
-			Text = "Error: Check the output.",
+			Text = "Error: Check the studio output (Window > Output)",
 			TextSize = 14,
 			TextTransparency = errorOffset.Z ^ 20,
 			TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.ErrorText),
-			TextXAlignment = if useUnderFrame then Enum.TextXAlignment.Center else Enum.TextXAlignment.Left,
+			TextWrapped = true,
+			TextXAlignment = Enum.TextXAlignment.Center, --if useUnderFrame then Enum.TextXAlignment.Center else Enum.TextXAlignment.Left,
 			TextYAlignment = if useUnderFrame then Enum.TextYAlignment.Top else Enum.TextYAlignment.Center,
 		}, {
 			UIStroke = React.createElement("UIStroke", {

--- a/src/Main/UserInterface/Components/CroppedViewport/init.luau
+++ b/src/Main/UserInterface/Components/CroppedViewport/init.luau
@@ -68,7 +68,7 @@ local function useLenseSize(size: Vector2, viewportSize: Vector2, scale: Vector2
 	return Vector2.new(clampedX, clampedY)
 end
 
-local function CroppedViewport(props: Props & { ViewportSize: Vector2 })
+local function CroppedViewport(props: Props & { ViewportSize: Vector2, ViewportPosition: Vector2 })
 	local theme = StudioComponents.useTheme()
 	local scaleOS = Hooks.useStatePath(function(state)
 		return state.temporary.scaleOS
@@ -212,6 +212,9 @@ local function CroppedViewport(props: Props & { ViewportSize: Vector2 })
 				Position = UDim2.new(0.5, 0, 1, actionBarPadding),
 				Size = UDim2.fromOffset(actionBarWidth, ACTION_BAR.Height),
 
+				ViewportSize = props.ViewportSize,
+				ViewportPosition = props.ViewportPosition,
+
 				DisplayedAbsSize = scaledLenseRectSize,
 				OnDimensionInput = function(dimensions)
 					setSize(useLenseSize(dimensions, scaledViewport, Vector2.new(1, 1), grabberMin))
@@ -248,6 +251,7 @@ end
 return function(props: Props)
 	local containerRef = React.useRef(nil :: GuiObject?)
 	local containerSize = Hooks.useRefProperty(containerRef, "AbsoluteSize", Vector2.zero)
+	local containerPosition = Hooks.useRefProperty(containerRef, "AbsolutePosition", Vector2.zero)
 
 	return React.createElement("Frame", {
 		Size = UDim2.fromScale(1, 1),
@@ -256,6 +260,7 @@ return function(props: Props)
 	}, {
 		CroppedViewport = React.createElement(CroppedViewport, {
 			ViewportSize = containerSize,
+			ViewportPosition = containerPosition,
 			InitialSize = props.InitialSize,
 			FocusLenseSizeRef = props.FocusLenseSizeRef,
 			OnMaximize = props.OnMaximize,

--- a/src/Main/UserInterface/Components/FullViewport/init.luau
+++ b/src/Main/UserInterface/Components/FullViewport/init.luau
@@ -22,6 +22,7 @@ type ActionBarProps = {
 	OnMinimize: () -> ()?,
 	OnCapture: (Rect) -> (boolean, string?),
 	IsDragging: boolean,
+	ContainerPosition: Vector2,
 	ContainerSize: Vector2,
 	Disabled: boolean,
 }
@@ -40,7 +41,7 @@ local function ActionBar(props: ActionBarProps)
 	local underFrameAbsPosition = Hooks.useRefProperty(underFrameRef, "AbsolutePosition", Vector2.zero)
 	local underFrameAbsSize = Hooks.useRefProperty(underFrameRef, "AbsoluteSize", Vector2.zero)
 	local underFrameBottomY = underFrameAbsPosition.Y + underFrameAbsSize.Y
-	local useUnderFrame = underFrameBottomY <= workspace.CurrentCamera.ViewportSize.Y
+	local useUnderFrame = underFrameBottomY <= (props.ContainerPosition.Y + props.ContainerSize.Y)
 
 	local shakeOffset, makeShake = Hooks.useShake()
 	local errorOffset, makeError = Hooks.useShake()
@@ -193,10 +194,11 @@ local function ActionBar(props: ActionBarProps)
 			Position = if useUnderFrame then UDim2.new(0, 0, 1, 2) else UDim2.new(0, 0, -1, -2),
 			Size = UDim2.fromScale(1, 1),
 			FontFace = Font.fromName("SourceSansPro", Enum.FontWeight.Bold, Enum.FontStyle.Normal),
-			Text = "Error: Check the output.",
+			Text = "Error: Check the studio output (Window > Output)",
 			TextSize = 14,
 			TextTransparency = errorOffset.Z ^ 20,
 			TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.ErrorText),
+			TextWrapped = true,
 			TextXAlignment = Enum.TextXAlignment.Center,
 			TextYAlignment = if useUnderFrame then Enum.TextYAlignment.Top else Enum.TextYAlignment.Bottom,
 		}, {
@@ -253,6 +255,7 @@ local function FullViewport(props: Props)
 	local isDragging, setIsDragging = React.useState(false)
 	local containerRef = React.useRef(nil :: GuiObject?)
 	local containerSize = Hooks.useRefProperty(containerRef, "AbsoluteSize", Vector2.zero)
+	local containerPosition = Hooks.useRefProperty(containerRef, "AbsolutePosition", Vector2.zero)
 
 	React.useEffect(function()
 		props.FocusLenseSizeRef.current = containerSize
@@ -291,6 +294,7 @@ local function FullViewport(props: Props)
 			}, {
 				ActionBar = React.createElement(ActionBar, {
 					IsDragging = isDragging,
+					ContainerPosition = containerPosition,
 					ContainerSize = containerSize,
 					OnMinimize = props.OnMinimize,
 					OnCapture = props.OnCapture,


### PR DESCRIPTION
This PR adds a more details message to the UI when the capture fails. This allows users to quickly identify how to access studio output.