### PR TITLE
Fix binding template typing

### DIFF
--- a/src/Main/Bindings/Interface/Templates/FitToFrame/Action.luau
+++ b/src/Main/Bindings/Interface/Templates/FitToFrame/Action.luau
@@ -59,7 +59,7 @@ end
 -- Capture
 
 local function capture()
-	local camera = workspace.CurrentCamera
+	local camera = workspace.CurrentCamera :: Camera
 	local viewportSize = camera.ViewportSize
 
 	local prevCameraCFrame = camera.CFrame

--- a/src/Main/Bindings/Interface/Templates/StaticFrame/Action.luau
+++ b/src/Main/Bindings/Interface/Templates/StaticFrame/Action.luau
@@ -53,7 +53,7 @@ local function validate()
 end
 
 local function capture()
-	local camera = workspace.CurrentCamera
+	local camera = workspace.CurrentCamera :: Camera
 
 	local prevCameraCFrame = camera.CFrame
 	local prevCameraType = camera.CameraType


### PR DESCRIPTION
`workspace.CurrentCamera` is marked as `Camera` via the lsp, but `Camera?` in studio. This causes a bunch of typing issues when you look at a template in studio. We fix this by simply hard casting the value.