### PR TITLE
Fix upload item line border

### DIFF
--- a/src/Main/UserInterface/Components/Gallery/UploadWindow/UploadLineItem.luau
+++ b/src/Main/UserInterface/Components/Gallery/UploadWindow/UploadLineItem.luau
@@ -228,7 +228,7 @@ local function UploadLineItem(props: Props)
 		Size = props.Size,
 
 		BackgroundColor3 = theme:GetColor(Enum.StudioStyleGuideColor.Titlebar),
-		BorderColor3 = theme:GetColor(Enum.StudioStyleGuideColor.Border),
+		BorderColor3 = theme:GetColor(Enum.StudioStyleGuideColor.DialogButtonBorder),
 
 		LayoutOrder = props.LayoutOrder,
 	}, {


### PR DESCRIPTION
This PR changes the border color used for the upload line items. When the themes changed with the new studio layout update this caused a border color change that didn't work well on dark mode.