### PR TITLE
Move render rect module

### DIFF
--- a/src/Main/Bindings/Interface/Helpers/RenderRect.luau
+++ b/src/Main/Bindings/Interface/Helpers/RenderRect.luau
@@ -20,4 +20,16 @@ function RenderRect.fromRect(rect: Rect)
 	return RenderRect.fromAbs(rect.Min, rect.Max - rect.Min)
 end
 
+function RenderRect.fromViewportCenter(size: Vector2)
+	local viewportSize = (workspace.CurrentCamera :: Camera).ViewportSize
+	local absPosition = (viewportSize - size) / 2
+	return RenderRect.fromAbs(absPosition, size)
+end
+
+function RenderRect.fromGuiObject(subject: GuiObject)
+	local absPosition = subject.AbsolutePosition
+	local absSize = subject.AbsoluteSize
+	return RenderRect.fromAbs(absPosition, absSize)
+end
+
 return RenderRect

--- a/src/Main/Bindings/Interface/Templates/FitToFrame/Action.luau
+++ b/src/Main/Bindings/Interface/Templates/FitToFrame/Action.luau
@@ -43,19 +43,6 @@ local function validate()
 	)
 end
 
-local function getRectFromGuiObject(subject: GuiObject)
-	local absPosition = subject.AbsolutePosition
-	local absSize = subject.AbsoluteSize
-
-	local minX = math.round(absPosition.X)
-	local minY = math.round(absPosition.Y)
-
-	local maxX = math.round(absPosition.X + absSize.X)
-	local maxY = math.round(absPosition.Y + absSize.Y)
-
-	return Rect.new(minX, minY, maxX, maxY)
-end
-
 -- Capture
 
 local function capture()
@@ -68,7 +55,7 @@ local function capture()
 	folder.Parent = nil
 
 	-- figure out the rect we're capturing and some math values we'll need to fit inside it
-	local rect = getRectFromGuiObject(frame)
+	local rect = Photobooth.rect.fromGuiObject(frame)
 	local aspect = rect.Width / rect.Height
 	local scaleY = rect.Height / viewportSize.Y
 	local scaledFov2 = math.atan(math.tan(math.rad(camera.FieldOfView / 2)) * scaleY)

--- a/src/Main/Bindings/Interface/Templates/StaticFrame/Action.luau
+++ b/src/Main/Bindings/Interface/Templates/StaticFrame/Action.luau
@@ -25,21 +25,6 @@ local Photobooth = require(ServerStorage.Photobooth.Bindings)
 local frame = script.Parent.CaptureFrame
 local folder = workspace:FindFirstChild("StaticFrameTargets") :: Folder
 
--- Helpers
-
-local function getRectFromGuiObject(subject: GuiObject)
-	local absPosition = subject.AbsolutePosition
-	local absSize = subject.AbsoluteSize
-
-	local minX = math.round(absPosition.X)
-	local minY = math.round(absPosition.Y)
-
-	local maxX = math.round(absPosition.X + absSize.X)
-	local maxY = math.round(absPosition.Y + absSize.Y)
-
-	return Rect.new(minX, minY, maxX, maxY)
-end
-
 -- Capture
 
 local function validate()
@@ -60,7 +45,7 @@ local function capture()
 	camera.CameraType = Enum.CameraType.Scriptable
 	folder.Parent = nil
 
-	local rect = getRectFromGuiObject(frame)
+	local rect = Photobooth.rect.fromGuiObject(frame)
 	local outputFolder = Instance.new("Folder")
 	for _, child in folder:GetChildren() do
 		child.Parent = workspace

--- a/src/Main/Bindings/Interface/init.luau
+++ b/src/Main/Bindings/Interface/init.luau
@@ -2,6 +2,7 @@
 
 local Types = require(script.Types)
 
+local RenderRect = require(script.Helpers.RenderRect)
 local Reversible = require(script.Helpers.Reversible)
 local CachelessRequire = require(script.Helpers.CachelessRequire)
 
@@ -25,6 +26,7 @@ local function invokeBinding<T..., U...>(identifier: string, ...: T...): U...
 	return table.unpack(results, 2)
 end
 
+Bindings.rect = RenderRect
 Bindings.reversible = Reversible.wrap
 
 function Bindings.execute(script: LuaSourceContainer)

--- a/src/Main/Bindings/Invocations/CaptureViewport.luau
+++ b/src/Main/Bindings/Invocations/CaptureViewport.luau
@@ -4,7 +4,7 @@ local pluginRoot = script:FindFirstAncestor("PluginRoot")
 local gt = require(pluginRoot.Packages.GreenTea)
 local Sift = require(pluginRoot.Packages.Sift)
 
-local RenderRect = require(pluginRoot.Utilities.RenderRect)
+local RenderRect = require(pluginRoot.Main.Bindings.Interface.Helpers.RenderRect)
 local Captures = require(pluginRoot.Main.Photo.Captures)
 local Camera = require(pluginRoot.Utilities.Camera)
 local State = require(pluginRoot.Main.State)

--- a/src/Main/Photo/Tools/UIBounds.luau
+++ b/src/Main/Photo/Tools/UIBounds.luau
@@ -1,7 +1,7 @@
 --!strict
 
 local pluginRoot = script:FindFirstAncestor("PluginRoot")
-local RenderRect = require(pluginRoot.Utilities.RenderRect)
+local RenderRect = require(pluginRoot.Main.Bindings.Interface.Helpers.RenderRect)
 local State = require(pluginRoot.Main.State)
 
 local ALWAYS_CLIPPED = true

--- a/src/Main/UserInterface/Components/CroppedViewport/init.luau
+++ b/src/Main/UserInterface/Components/CroppedViewport/init.luau
@@ -5,7 +5,7 @@ local StudioComponents = require(pluginRoot.Packages.StudioComponents)
 local React = require(pluginRoot.Packages.React)
 local Sift = require(pluginRoot.Packages.Sift)
 
-local RenderRect = require(pluginRoot.Utilities.RenderRect)
+local RenderRect = require(pluginRoot.Main.Bindings.Interface.Helpers.RenderRect)
 local Constants = require(pluginRoot.Constants)
 
 local ActionBar = require(script.ActionBar)


### PR DESCRIPTION
# Problem

Generating rects for use in binding code and throughout the plugin typically requires a helper module to do proper rounding. I already have a module for doing these adjustments, but it was not publically accessible by bindings. This resulted in duplicate code stored in the bindings.

# Solution

I made the `RenderRect` module a binding helper. This ensures that it can be accessed by bindings and the plugin source alike. Additionally I was able to include some QoL functions such as `RenderRect.fromViewportCenter` and `RenderRect.fromGuiObject` which are nice when writing binding code.