### PR TITLE
Fix wally package license

### DIFF
--- a/lune/create-bindings-package.luau
+++ b/lune/create-bindings-package.luau
@@ -6,6 +6,7 @@ if fs.isDir("bindings-package") then
 end
 
 fs.copy("src/Main/Bindings/Interface", "bindings-package")
+fs.copy("LICENSE", "bindings-package/LICENSE")
 
 local wallyToml = serde.decode("toml", fs.readFile("wally.toml"))
 local package = wallyToml.package
@@ -13,11 +14,12 @@ package.name = package.name:split("/")[1] .. "/photobooth-bindings"
 package.description = "Bindings for use with the photobooth plugin."
 package.private = nil
 package.exclude = { "**" }
-package.include = { "src", "src/**", "wally.toml", "default.project.json" }
+package.include = { "src", "src/**", "LICENSE", "wally.toml", "default.project.json" }
 fs.writeFile("bindings-package/wally.toml", serde.encode("toml", { package = package }, false))
 
 local defaultProject = serde.decode("json", fs.readFile("bindings-package/default.project.json"))
 defaultProject.name = "photobooth-bindings"
-defaultProject.tree.Wally["$path"] = "../wally.toml"
-defaultProject.tree.LICENSE["$path"] = "../LICENSE"
+defaultProject.tree.Wally["$path"] = "wally.toml"
+defaultProject.tree.LICENSE["$path"] = "LICENSE"
+defaultProject.syncRules[1].pattern = "LICENSE"
 fs.writeFile("bindings-package/default.project.json", serde.encode("json", defaultProject, true))


### PR DESCRIPTION
# Problem

The wally package wasn't working properly b/c it was syncing files that were from the project root.

# Solution

Copying the files into the package folder and syncing those instead fixes the issue.