### PR TITLE
Jfa bleed fixes

### DIFF
--- a/src/Constants.luau
+++ b/src/Constants.luau
@@ -7,7 +7,7 @@ return {
 	AllowExperimentalMode = true,
 
 	JFAPlusOne = false,
-	JFAActorCount = 4,
+	JFAActorCount = 32,
 
 	TileHighResImagesEnabled = true,
 	TileHighResImagesSize = { X = 1024, Y = 1024 },

--- a/src/Constants.luau
+++ b/src/Constants.luau
@@ -7,7 +7,7 @@ return {
 	AllowExperimentalMode = true,
 
 	JFAPlusOne = false,
-	JFAActorCount = 32,
+	JFAActorCount = 4,
 
 	TileHighResImagesEnabled = true,
 	TileHighResImagesSize = { X = 1024, Y = 1024 },

--- a/src/Main/Photo/Captures/CaptureTypes/UserInterface/AlphaMask.luau
+++ b/src/Main/Photo/Captures/CaptureTypes/UserInterface/AlphaMask.luau
@@ -42,7 +42,7 @@ local function operation(options: Types.CaptureUIOptions, trove: Trove.Trove)
 
 	local capture = Composers.reverseBlend(onWhite, onBlack, nil, colorCorrection)
 	if options.alphaBleed then
-		capture = Composers.alphaBleedJFA(capture)
+		capture = Composers.alphaBleed(capture)
 	end
 
 	return capture

--- a/src/Main/Photo/Captures/CaptureTypes/UserInterface/NoBackground.luau
+++ b/src/Main/Photo/Captures/CaptureTypes/UserInterface/NoBackground.luau
@@ -41,7 +41,7 @@ local function operation(options: Types.CaptureUIOptions, trove: Trove.Trove)
 
 	local capture = Composers.reverseBlend(onWhite, onBlack, nil, colorCorrection)
 	if options.alphaBleed then
-		capture = Composers.alphaBleedJFA(capture)
+		capture = Composers.alphaBleed(capture)
 	end
 
 	return capture

--- a/src/Main/Photo/Captures/CaptureTypes/Viewport/Experimental_NSB_A1.luau
+++ b/src/Main/Photo/Captures/CaptureTypes/Viewport/Experimental_NSB_A1.luau
@@ -80,7 +80,7 @@ local function operation(options: Types.CaptureViewportOptions, trove: Trove.Tro
 	-- remove background & alpha bleed
 	local capture = Composers.reverseBlend(onWhiteRetro, onBlackRetro, gradedOnBlack, colorCorrection)
 	if options.alphaBleed then
-		capture = Composers.alphaBleedJFA(capture)
+		capture = Composers.alphaBleed(capture)
 	end
 
 	return capture

--- a/src/Main/Photo/Captures/CaptureTypes/Viewport/NoSkybox.luau
+++ b/src/Main/Photo/Captures/CaptureTypes/Viewport/NoSkybox.luau
@@ -56,7 +56,7 @@ local function operation(options: Types.CaptureViewportOptions, trove: Trove.Tro
 
 	local capture = Composers.reverseBlend(onWhiteRetro, onBlackRetro, gradedOnBlack, colorCorrection)
 	if options.alphaBleed then
-		capture = Composers.alphaBleedJFA(capture)
+		capture = Composers.alphaBleed(capture)
 	end
 
 	return capture

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/Bleed/init.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/Bleed/init.luau
@@ -6,12 +6,12 @@ local Constants = require(pluginRoot.Constants)
 
 type WorkerAction = typeof(require(script.Worker))
 
-local scheduler = Parallel.new(Constants.JFAActorCount, {
-	script = script.Worker,
-	typecast = (nil :: any) :: WorkerAction,
-})
-
 local function bleed(img: EditableImage, voronoi: EditableImage, regions: { Rect }, workingBbox: Rect)
+	local scheduler = Parallel.new(Constants.JFAActorCount, {
+		script = script.Worker,
+		typecast = (nil :: any) :: WorkerAction,
+	})
+
 	scheduler:waitForReady()
 
 	for _, crop in regions do
@@ -22,6 +22,8 @@ local function bleed(img: EditableImage, voronoi: EditableImage, regions: { Rect
 	local stitched = buffer.create(workingBbox.Width * workingBbox.Height * 4)
 
 	local results = scheduler:workAsync()
+	scheduler:Destroy()
+
 	for i, getCropBuffer in results do
 		local cropBuffer = getCropBuffer()
 		buffer.copy(stitched, offset, cropBuffer)

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/Bleed/init.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/Bleed/init.luau
@@ -3,7 +3,6 @@
 local pluginRoot = script:FindFirstAncestor("PluginRoot")
 local Parallel = require(pluginRoot.Packages.Parallel)
 local Constants = require(pluginRoot.Constants)
-local Image = require(pluginRoot.Utilities.Image)
 
 type WorkerAction = typeof(require(script.Worker))
 

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/Bleed/init.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/Bleed/init.luau
@@ -15,33 +15,21 @@ local scheduler = Parallel.new(Constants.JFAActorCount, {
 local function bleed(img: EditableImage, voronoi: EditableImage, regions: { Rect }, workingBbox: Rect)
 	scheduler:waitForReady()
 
-	local imgSize = img.Size
-	local imgWidth = imgSize.X
-
 	for _, crop in regions do
 		scheduler:schedule(img, voronoi, crop)
 	end
 
-	local stitched = img:ReadPixelsBuffer(Vector2.zero, imgSize)
+	local offset = 0
+	local stitched = buffer.create(workingBbox.Width * workingBbox.Height * 4)
 
-	local bboxMinX = workingBbox.Min.X
 	local results = scheduler:workAsync()
 	for i, getCropBuffer in results do
 		local cropBuffer = getCropBuffer()
-		local crop = regions[i]
-		local cropWidth = crop.Max.X - crop.Min.X
-		local cropHeight = crop.Max.Y - crop.Min.Y
-		local cropMinY = crop.Min.Y
-
-		local rowBytes = cropWidth * 4
-		for row = 0, cropHeight - 1 do
-			local srcOffset = row * rowBytes
-			local destOffset = ((cropMinY + row) * imgWidth + bboxMinX) * 4
-			buffer.copy(stitched, destOffset, cropBuffer, srcOffset, rowBytes)
-		end
+		buffer.copy(stitched, offset, cropBuffer)
+		offset = offset + buffer.len(cropBuffer)
 	end
 
-	return stitched
+	img:WritePixelsBuffer(workingBbox.Min, workingBbox.Max - workingBbox.Min, stitched)
 end
 
 return bleed

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/JFAPasses/init.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/JFAPasses/init.luau
@@ -7,11 +7,6 @@ local Constants = require(pluginRoot.Constants)
 
 type WorkerAction = typeof(require(script.Worker))
 
-local scheduler = Parallel.new(Constants.JFAActorCount, {
-	script = script.Worker,
-	typecast = (nil :: any) :: WorkerAction,
-})
-
 local function firstPassJFA(
 	img: EditableImage,
 	voronoi: EditableImage,
@@ -19,6 +14,11 @@ local function firstPassJFA(
 	workingBbox: Rect,
 	nBleedPixels: number?
 )
+	local scheduler = Parallel.new(Constants.JFAActorCount, {
+		script = script.Worker,
+		typecast = (nil :: any) :: WorkerAction,
+	})
+
 	scheduler:waitForReady()
 
 	local bboxSize = workingBbox.Max - workingBbox.Min
@@ -57,6 +57,8 @@ local function firstPassJFA(
 
 		voronoi:WritePixelsBuffer(workingBbox.Min, bboxSize, stitched)
 	end
+
+	scheduler:Destroy()
 
 	return #passSteps
 end

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/PlantSeeds/init.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/PlantSeeds/init.luau
@@ -6,12 +6,12 @@ local Constants = require(pluginRoot.Constants)
 
 type WorkerAction = typeof(require(script.Worker))
 
-local scheduler = Parallel.new(Constants.JFAActorCount, {
-	script = script.Worker,
-	typecast = (nil :: any) :: WorkerAction,
-})
-
 local function plantSeeds(img: EditableImage, voronoi: EditableImage, regions: { Rect }): Rect?
+	local scheduler = Parallel.new(Constants.JFAActorCount, {
+		script = script.Worker,
+		typecast = (nil :: any) :: WorkerAction,
+	})
+
 	scheduler:waitForReady()
 
 	local imgSize = img.Size
@@ -29,6 +29,8 @@ local function plantSeeds(img: EditableImage, voronoi: EditableImage, regions: {
 	local tXMax, tYMax = -math.huge, -math.huge
 
 	local results = scheduler:workAsync()
+	scheduler:Destroy()
+
 	for i, getCropBuffer in results do
 		local cropBuffer, chunkHasOpaque, cXMin, cYMin, cXMax, cYMax = getCropBuffer()
 		buffer.copy(stitched, offset, cropBuffer)

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/init.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/init.luau
@@ -60,9 +60,9 @@ local function alphaBleedJFA(img: Image.Image)
 		local nPasses = JFAPasses(imgEdit, voronoiEdit, jfaRegions, workingBbox)
 
 		if nPasses > 0 then
-			local bledBuffer = Bleed(imgEdit, voronoiEdit, jfaRegions, workingBbox)
+			Bleed(imgEdit, voronoiEdit, jfaRegions, workingBbox)
 
-			local bledImg = Image.fromBuffer(bledBuffer, img.size)
+			local bledImg = Image.fromEditableImage(imgEdit)
 			bledImg.templateUri = img.templateUri
 			resultImg = bledImg
 		end

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/init.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/init.luau
@@ -45,8 +45,11 @@ local function sliceIntoStrips(region: Rect, nSlices: number)
 end
 
 local function alphaBleedJFA(img: Image.Image)
+	print("alphaBleedJFA: entering")
 	local imgEdit = img:Save()
+	print("alphaBleedJFA: imgEdit saved")
 	local voronoiEdit = img:Save()
+	print("alphaBleedJFA: voronoiEdit saved")
 
 	local bledImg
 	local success, err: string? = pcall(function()
@@ -55,13 +58,16 @@ local function alphaBleedJFA(img: Image.Image)
 		local plantRegions = sliceIntoStrips(fullRegion, Constants.JFAActorCount)
 
 		local workingBbox = PlantSeeds(imgEdit, voronoiEdit, plantRegions)
+		print("Seeds planted")
 
 		if workingBbox then
 			local jfaRegions = sliceIntoStrips(workingBbox, Constants.JFAActorCount)
 			local nPasses = JFAPasses(imgEdit, voronoiEdit, jfaRegions, workingBbox)
+			print("JFA passes done")
 
 			if nPasses > 0 then
 				Bleed(imgEdit, voronoiEdit, jfaRegions, workingBbox)
+				print("Bled")
 
 				bledImg = Image.fromEditableImage(imgEdit)
 				bledImg.templateUri = img.templateUri

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/init.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/init.luau
@@ -45,11 +45,8 @@ local function sliceIntoStrips(region: Rect, nSlices: number)
 end
 
 local function alphaBleedJFA(img: Image.Image)
-	print("alphaBleedJFA: entering")
 	local imgEdit = img:Save()
-	print("alphaBleedJFA: imgEdit saved")
 	local voronoiEdit = img:Save()
-	print("alphaBleedJFA: voronoiEdit saved")
 
 	local bledImg
 	local success, err: string? = pcall(function()
@@ -58,16 +55,13 @@ local function alphaBleedJFA(img: Image.Image)
 		local plantRegions = sliceIntoStrips(fullRegion, Constants.JFAActorCount)
 
 		local workingBbox = PlantSeeds(imgEdit, voronoiEdit, plantRegions)
-		print("Seeds planted")
 
 		if workingBbox then
 			local jfaRegions = sliceIntoStrips(workingBbox, Constants.JFAActorCount)
 			local nPasses = JFAPasses(imgEdit, voronoiEdit, jfaRegions, workingBbox)
-			print("JFA passes done")
 
 			if nPasses > 0 then
 				Bleed(imgEdit, voronoiEdit, jfaRegions, workingBbox)
-				print("Bled")
 
 				bledImg = Image.fromEditableImage(imgEdit)
 				bledImg.templateUri = img.templateUri

--- a/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/init.luau
+++ b/src/Main/Photo/Captures/Composers/Parallel/AlphaBleedJFA/init.luau
@@ -47,31 +47,36 @@ end
 local function alphaBleedJFA(img: Image.Image)
 	local imgEdit = img:Save()
 	local voronoiEdit = img:Save()
-	local resultImg = img
 
-	local imgSize = imgEdit.Size
-	local fullRegion = Rect.new(0, 0, imgSize.X, imgSize.Y)
-	local plantRegions = sliceIntoStrips(fullRegion, Constants.JFAActorCount)
+	local bledImg
+	local success, err: string? = pcall(function()
+		local imgSize = imgEdit.Size
+		local fullRegion = Rect.new(0, 0, imgSize.X, imgSize.Y)
+		local plantRegions = sliceIntoStrips(fullRegion, Constants.JFAActorCount)
 
-	local workingBbox = PlantSeeds(imgEdit, voronoiEdit, plantRegions)
+		local workingBbox = PlantSeeds(imgEdit, voronoiEdit, plantRegions)
 
-	if workingBbox then
-		local jfaRegions = sliceIntoStrips(workingBbox, Constants.JFAActorCount)
-		local nPasses = JFAPasses(imgEdit, voronoiEdit, jfaRegions, workingBbox)
+		if workingBbox then
+			local jfaRegions = sliceIntoStrips(workingBbox, Constants.JFAActorCount)
+			local nPasses = JFAPasses(imgEdit, voronoiEdit, jfaRegions, workingBbox)
 
-		if nPasses > 0 then
-			Bleed(imgEdit, voronoiEdit, jfaRegions, workingBbox)
+			if nPasses > 0 then
+				Bleed(imgEdit, voronoiEdit, jfaRegions, workingBbox)
 
-			local bledImg = Image.fromEditableImage(imgEdit)
-			bledImg.templateUri = img.templateUri
-			resultImg = bledImg
+				bledImg = Image.fromEditableImage(imgEdit)
+				bledImg.templateUri = img.templateUri
+			end
 		end
-	end
+	end)
 
 	imgEdit:Destroy()
 	voronoiEdit:Destroy()
 
-	return resultImg
+	if not success and err then
+		error(err, 0)
+	end
+
+	return bledImg
 end
 
 return alphaBleedJFA

--- a/src/Main/Photo/Captures/Composers/init.luau
+++ b/src/Main/Photo/Captures/Composers/init.luau
@@ -5,7 +5,6 @@ local parallelFolder = script.Parallel
 
 return {
 	alphaBleed = require(parallelFolder.AlphaBleed),
-	alphaBleedJFA = require(parallelFolder.AlphaBleedJFA),
 	reverseBlend = require(parallelFolder.ReverseBlend),
 	fullyOpaque = require(serialFolder.FullyOpaque),
 }

--- a/src/Main/Photo/Captures/Screenshot.luau
+++ b/src/Main/Photo/Captures/Screenshot.luau
@@ -9,6 +9,8 @@ local Image = require(pluginRoot.Utilities.Image)
 local Constants = require(pluginRoot.Constants)
 local State = require(pluginRoot.Main.State)
 
+local OS_MISMATCH = "OS Scale mismatch. You may need to go into photobooth settings and refresh the OS scale value."
+
 local Screenshot = {}
 
 -- Private
@@ -30,22 +32,28 @@ end
 local function screenshot(rect: Rect?)
 	local editImage, contentUri = captureEditableImage()
 
-	local viewportSize = workspace.CurrentCamera.ViewportSize :: Vector2
-	local scale = editImage.Size / viewportSize
+	local result
+	local success, err: string? = pcall(function()
+		local viewportSize = workspace.CurrentCamera.ViewportSize :: Vector2
+		local scale = editImage.Size / viewportSize
 
-	if scale ~= State.read().temporary.scaleOS then
-		error("WARN: OS Scale mismatch. You may need to go into photobooth settings and refresh the OS scale value.", 0)
+		if scale ~= State.read().temporary.scaleOS then
+			error("WARN: " .. OS_MISMATCH, 0)
+		end
+
+		result = Image.fromEditableImage(editImage, rect)
+		if not rect then
+			result:SetTemplateUri(contentUri)
+		end
+	end)
+
+	editImage:Destroy()
+
+	if not success and err then
+		error(err, 0)
 	end
 
-	local img = Image.fromEditableImage(editImage, rect)
-
-	if rect then
-		editImage:Destroy()
-	else
-		img:SetTemplateUri(contentUri)
-	end
-
-	return img
+	return result
 end
 
 -- Public

--- a/src/Main/Photo/Captures/Screenshot.luau
+++ b/src/Main/Photo/Captures/Screenshot.luau
@@ -16,20 +16,25 @@ local Screenshot = {}
 -- Private
 
 local function captureEditableImage()
+	print("captureEditableImage: requesting CaptureScreenshot")
 	local contentUriFuture = Future.new() :: Future.Future<string>
 	CaptureService:CaptureScreenshot(function(contentUri: string)
 		-- this is a significant bottleneck for speed
 		-- it can take roughly 0.3 seconds to complete
+		print("captureEditableImage: CaptureScreenshot callback fired")
 		contentUriFuture:complete(contentUri)
 	end)
 
 	local contentUri = contentUriFuture:expect()
+	print("captureEditableImage: contentUri obtained, calling CreateEditableImageAsync")
 	local editImage = AssetService:CreateEditableImageAsync(Content.fromUri(contentUri)) :: EditableImage
+	print("captureEditableImage: editable image created")
 
 	return editImage, contentUri
 end
 
 local function screenshot(rect: Rect?)
+	print("screenshot: entering")
 	local editImage, contentUri = captureEditableImage()
 
 	local result

--- a/src/Main/Photo/Captures/Screenshot.luau
+++ b/src/Main/Photo/Captures/Screenshot.luau
@@ -16,25 +16,20 @@ local Screenshot = {}
 -- Private
 
 local function captureEditableImage()
-	print("captureEditableImage: requesting CaptureScreenshot")
 	local contentUriFuture = Future.new() :: Future.Future<string>
 	CaptureService:CaptureScreenshot(function(contentUri: string)
 		-- this is a significant bottleneck for speed
 		-- it can take roughly 0.3 seconds to complete
-		print("captureEditableImage: CaptureScreenshot callback fired")
 		contentUriFuture:complete(contentUri)
 	end)
 
 	local contentUri = contentUriFuture:expect()
-	print("captureEditableImage: contentUri obtained, calling CreateEditableImageAsync")
 	local editImage = AssetService:CreateEditableImageAsync(Content.fromUri(contentUri)) :: EditableImage
-	print("captureEditableImage: editable image created")
 
 	return editImage, contentUri
 end
 
 local function screenshot(rect: Rect?)
-	print("screenshot: entering")
 	local editImage, contentUri = captureEditableImage()
 
 	local result


### PR DESCRIPTION
Fixes a few memory leaks and disables the use of parallel JFA.

Unfortunately there's a bug w/ parallel luau and reading pixel buffers from editable images that causes hard crashes in studio. I've reported it here:
https://devforum.roblox.com/t/crash-when-using-parallel-luau-and-editable-images/4636165

Until this is fixed the JFA bleed is untenable b/c it has a chance of crashing your PC :(