### PR TITLE
Add get mesh part

### DIFF
--- a/src/Main/Bindings/Interface/src/init.luau
+++ b/src/Main/Bindings/Interface/src/init.luau
@@ -40,6 +40,10 @@ function Bindings.yieldUntilNextFrame(): ()
 	return Binding.invoke("yieldUntilNextFrame")
 end
 
+function Bindings.getMeshPart(): MeshPart
+	return Binding.invoke("getMeshPart")
+end
+
 function Bindings.captureViewport(options: CaptureViewportOptions): MeshPart?
 	return Binding.invoke("captureViewport", options)
 end

--- a/src/Main/Bindings/Invocations/CaptureUI.luau
+++ b/src/Main/Bindings/Invocations/CaptureUI.luau
@@ -20,7 +20,7 @@ local gtOptions = gt.table({
 -- stylua: ignore
 local typechecker = gt.fn(
 	gt.args(gtOptions),
-	gt.returns(gt.opt(gt.IsA("MeshPart")))
+	gt.returns(gt.opt(gt.isA.MeshPart()))
 )
 
 local function callback(options: typeof(gtOptions))

--- a/src/Main/Bindings/Invocations/CaptureViewport.luau
+++ b/src/Main/Bindings/Invocations/CaptureViewport.luau
@@ -23,7 +23,7 @@ local gtOptions = gt.table({
 -- stylua: ignore
 local typechecker = gt.fn(
 	gt.args(gtOptions),
-	gt.returns(gt.opt(gt.IsA("MeshPart")))
+	gt.returns(gt.opt(gt.isA.MeshPart()))
 )
 
 local function callback(options: typeof(gtOptions))

--- a/src/Main/Bindings/Invocations/GetMeshPart.luau
+++ b/src/Main/Bindings/Invocations/GetMeshPart.luau
@@ -1,0 +1,19 @@
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local gt = require(pluginRoot.Packages.GreenTea)
+
+local Photo = require(pluginRoot.Main.Photo)
+
+-- stylua: ignore
+local typechecker = gt.fn(
+	gt.args(),
+	gt.returns(gt.isA.MeshPart())
+)
+
+local function callback()
+	return Photo.getQuadMeshPart()
+end
+
+return {
+	identifier = "getMeshPart",
+	callback = gt.wrapFn(typechecker, callback),
+}

--- a/src/Main/Photo/init.luau
+++ b/src/Main/Photo/init.luau
@@ -38,7 +38,7 @@ local function createIsCapturingTrove()
 end
 
 local quadFuture: Future.Future<MeshPart>
-local function getQuadMeshPart()
+local function getQuadMeshPartTemplate()
 	if not quadFuture then
 		local editMesh = AssetService:CreateEditableMesh({ FixedSize = false })
 
@@ -69,6 +69,12 @@ local function getQuadMeshPart()
 		editMesh:Destroy()
 
 		local meshPart = AssetService:CreateMeshPartAsync(Content.fromObject(fixedMesh))
+		meshPart.Anchored = true
+		meshPart.CanCollide = false
+		meshPart.CanTouch = false
+		meshPart.Transparency = 0 -- cannot be transparent
+		meshPart.Size = Vector3.new(1, 1, 0)
+
 		quadFuture = Future.completed(meshPart)
 	end
 
@@ -146,19 +152,19 @@ function Photo.captureViewport(options: Types.CaptureViewportOptions)
 	return results, err
 end
 
+function Photo.getQuadMeshPart()
+	local copy = getQuadMeshPartTemplate():Clone()
+	copy.Archivable = false
+	return copy
+end
+
 function Photo.export(imgs: { Image.Image }, parent: Instance?)
 	local results = {}
 
 	for i, img in imgs do
 		local name = `{DateTime.now():ToIsoDate()}_{i}`
-		local meshPart = getQuadMeshPart():Clone()
-		meshPart.Archivable = false
-		meshPart.Anchored = true
-		meshPart.CanCollide = false
-		meshPart.CanTouch = false
-		meshPart.Transparency = 0 -- cannot be transparent
+		local meshPart = Photo.getQuadMeshPart()
 		meshPart.Name = name
-		meshPart.Size = Vector3.new(1, 1, 0)
 		meshPart.TextureContent = Content.fromObject(img:Save())
 		meshPart.Parent = parent
 
@@ -175,14 +181,8 @@ function Photo.importFiles(parent: Instance?)
 		local content = Content.fromUri(file:GetTemporaryId())
 		local editImage = AssetService:CreateEditableImageAsync(content)
 
-		local meshPart = getQuadMeshPart():Clone()
-		meshPart.Archivable = false
-		meshPart.Anchored = true
-		meshPart.CanCollide = false
-		meshPart.CanTouch = false
-		meshPart.Transparency = 0 -- cannot be transparent
+		local meshPart = Photo.getQuadMeshPart()
 		meshPart.Name = file.Name:match("(.+)%.[^.]*$") or file.Name
-		meshPart.Size = Vector3.new(1, 1, 1)
 		meshPart.TextureContent = Content.fromObject(editImage)
 		meshPart.Parent = parent
 


### PR DESCRIPTION
# Problem

When exporting to gltf you need an actual mesh. Internally I use a quad I created, but this can be a pain if you're working in bindings.

# Solution

This PR adds a binding method for getting a copy of the quad mesh part. Makes it really easy to set your own editable images to it for gltf export.