### PR TITLE
Make the ViewportApp ScreenGui always be able to receive input

### DIFF
--- a/src/Main/UserInterface/init.luau
+++ b/src/Main/UserInterface/init.luau
@@ -96,8 +96,8 @@ end
 function UserInterface.mountCaptureViewport(plugin: Plugin, toolbar: PluginToolbar)
 	-- stylua: ignore
 	local openButton = toolbar:CreateButton(
-		"egomoose_photobooth_viewport_button", 
-		"Capture viewport images", 
+		"egomoose_photobooth_viewport_button",
+		"Capture viewport images",
 		"", "Viewport"
 	)
 
@@ -183,6 +183,7 @@ function UserInterface.mountCaptureViewport(plugin: Plugin, toolbar: PluginToolb
 		-- stylua: ignore
 		return isEnabled and React.createElement("ScreenGui", {
 			Name = "ViewportApp",
+			DisplayOrder = math.huge, -- this is so enabled ScreenGuis in say StarterGui don't stop Photobooth from receiving input
 			Archivable = false,
 			IgnoreGuiInset = true,
 			ZIndexBehavior = Enum.ZIndexBehavior.Sibling,


### PR DESCRIPTION
# Problem

Enabled ScreenGuis that have a visible element with a size of `Udmi2.fromScale(1, 1)` would block input to the ViewportApp ScreenGui Photobooth uses.

# Solution

Fixed by giving the ViewportApp ScreenGui a DisplayOrder of `math.huge` so it can still receive inputs.