### PR TITLE
Fix compatibility check

### DIFF
--- a/src/Main/Bindings/Invocations/CompatibilityCheck.luau
+++ b/src/Main/Bindings/Invocations/CompatibilityCheck.luau
@@ -15,7 +15,7 @@ local function callback(version: string)
 	if Semver.validateVersion(Wally.package.version) and Semver.validateVersion(version) then
 		local wallyVersion = CargoSemver.Version.parse(Wally.package.version)
 		local checkVersion = CargoSemver.Version.parse(version)
-		return checkVersion.major == wallyVersion.major and checkVersion.minor >= wallyVersion.minor
+		return checkVersion.major == wallyVersion.major and checkVersion.minor <= wallyVersion.minor
 	end
 	return false
 end


### PR DESCRIPTION
I had the logic for my compatibility checks backwards. I if we're on the same major version but the minor version differs then you should only pass the compat check if the minor version you are checking is less than or equal to the minor version of installed photobooth. This ensures that you cannot call a function that doesn't exist if the compat check passes.