### PR TITLE
Add black background option

### DIFF
--- a/src/Builds/Plugin.luau
+++ b/src/Builds/Plugin.luau
@@ -81,6 +81,7 @@ function Plugin.build(plugin: Plugin)
 	UserInterface.mountCaptureViewport(plugin, toolbar)
 	UserInterface.mountCaptureUI(plugin, toolbar)
 	UserInterface.mountGallery(plugin, toolbar)
+	UserInterface.mountBlackout(plugin)
 
 	Bindings.setup(plugin)
 end

--- a/src/Main/Photo/Captures/CaptureTypes/Viewport/Experimental_NSB_A1.luau
+++ b/src/Main/Photo/Captures/CaptureTypes/Viewport/Experimental_NSB_A1.luau
@@ -57,8 +57,8 @@ local function operation(options: Types.CaptureViewportOptions, trove: Trove.Tro
 	trove:Add(SceneControl.applyRetroLighting())
 
 	local fogBackground = Background.new(workspace)
-	fogBackground:SetColor(Color3.new(0, 0, 0))
-	fogBackground:SetEnabled(true)
+	fogBackground:setColor(Color3.new(0, 0, 0))
+	fogBackground:setEnabled(true)
 
 	trove:Add(SceneControl.once(function()
 		fogBackground:Destroy()
@@ -71,7 +71,7 @@ local function operation(options: Types.CaptureViewportOptions, trove: Trove.Tro
 	local onBlackRetro = Screenshot.rect(options.rect)
 
 	-- capture on retro white
-	fogBackground:SetColor(Color3.new(1, 1, 1))
+	fogBackground:setColor(Color3.new(1, 1, 1))
 	SceneControl.yieldUntilNextFrame()
 	local onWhiteRetro = Screenshot.rect(options.rect)
 

--- a/src/Main/Photo/Captures/CaptureTypes/Viewport/NoSkybox.luau
+++ b/src/Main/Photo/Captures/CaptureTypes/Viewport/NoSkybox.luau
@@ -23,8 +23,8 @@ local function operation(options: Types.CaptureViewportOptions, trove: Trove.Tro
 	local colorCorrection = trove:Add(SceneControl.getAppliedColorCorrectionCopy())
 
 	local fogBackground = Background.new(workspace)
-	fogBackground:SetColor(Color3.new(0, 0, 0))
-	fogBackground:SetEnabled(true)
+	fogBackground:setColor(Color3.new(0, 0, 0))
+	fogBackground:setEnabled(true)
 
 	trove:Add(SceneControl.once(function()
 		fogBackground:Destroy()
@@ -48,7 +48,7 @@ local function operation(options: Types.CaptureViewportOptions, trove: Trove.Tro
 	local onBlackRetro = Screenshot.rect(options.rect)
 
 	-- capture on retro white
-	fogBackground:SetColor(Color3.new(1, 1, 1))
+	fogBackground:setColor(Color3.new(1, 1, 1))
 	SceneControl.yieldUntilNextFrame()
 	local onWhiteRetro = Screenshot.rect(options.rect)
 

--- a/src/Main/Photo/Tools/Background/BillboardBackground.luau
+++ b/src/Main/Photo/Tools/Background/BillboardBackground.luau
@@ -19,8 +19,8 @@ function BillboardBackgroundClass.new(parent: Instance): BillboardBackground
 	self.part, self.billboard, self.frame = self:_createInstances()
 	self.part.Parent = parent
 
-	self:SetEnabled(false)
-	self:Update()
+	self:setEnabled(false)
+	self:render()
 
 	return self
 end
@@ -78,7 +78,7 @@ local function getBoundsIntersection(cameraCF: CFrame)
 	return cameraCF.Position + lookVector * math.max(0, t + 1)
 end
 
-function BillboardBackgroundClass._createInstances(self: BillboardBackground)
+function BillboardBackgroundClass._createInstances(_self: BillboardBackground)
 	local part = Instance.new("Part")
 	part.CFrame = CFrame.identity
 	part.Size = Vector3.new(1, 1, 1)
@@ -105,15 +105,15 @@ end
 
 -- Public
 
-function BillboardBackgroundClass.Update(self: BillboardBackground)
+function BillboardBackgroundClass.render(self: BillboardBackground)
 	self.part.CFrame = CFrame.new(getBoundsIntersection(workspace.CurrentCamera.CFrame))
 end
 
-function BillboardBackgroundClass.SetEnabled(self: BillboardBackground, enabled: boolean)
+function BillboardBackgroundClass.setEnabled(self: BillboardBackground, enabled: boolean)
 	self.billboard.Enabled = enabled
 end
 
-function BillboardBackgroundClass.SetColor(self: BillboardBackground, color: Color3)
+function BillboardBackgroundClass.setColor(self: BillboardBackground, color: Color3)
 	self.frame.BackgroundColor3 = color
 end
 

--- a/src/Main/Photo/Tools/Background/MeshPartFogBackground.luau
+++ b/src/Main/Photo/Tools/Background/MeshPartFogBackground.luau
@@ -30,8 +30,8 @@ function MeshPartFogBackgroundClass.new(parent: Instance): MeshPartFogBackground
 	self.fogDistance = -1
 	self.fogTrove = Trove.new()
 
-	self:SetEnabled(false)
-	self:Render()
+	self:setEnabled(false)
+	self:render()
 
 	return self
 end
@@ -79,14 +79,14 @@ end
 
 -- Public
 
-function MeshPartFogBackgroundClass.Render(self: MeshPartFogBackground)
+function MeshPartFogBackgroundClass.render(self: MeshPartFogBackground)
 	local cameraCF = workspace.CurrentCamera.CFrame
 	local intersection = getBoundsIntersection(cameraCF)
 	self.part.CFrame = CFrame.new(intersection) * cameraCF.Rotation
 	self.fogDistance = -cameraCF:PointToObjectSpace(intersection).Z - MARGIN_OF_ERROR_DISTANCE
 end
 
-function MeshPartFogBackgroundClass.SetEnabled(self: MeshPartFogBackground, enabled: boolean)
+function MeshPartFogBackgroundClass.setEnabled(self: MeshPartFogBackground, enabled: boolean)
 	self.part.Transparency = if enabled then 0 else 1
 	if enabled and self.fogDistance > 0 then
 		local color = Lighting.FogColor
@@ -106,7 +106,7 @@ function MeshPartFogBackgroundClass.SetEnabled(self: MeshPartFogBackground, enab
 	end
 end
 
-function MeshPartFogBackgroundClass.SetColor(self: MeshPartFogBackground, color: Color3)
+function MeshPartFogBackgroundClass.setColor(self: MeshPartFogBackground, color: Color3)
 	self.part.Color = color
 	if self.part.Transparency == 0 then
 		Lighting.FogColor = color
@@ -114,7 +114,7 @@ function MeshPartFogBackgroundClass.SetColor(self: MeshPartFogBackground, color:
 end
 
 function MeshPartFogBackgroundClass.Destroy(self: MeshPartFogBackground)
-	self:SetEnabled(false)
+	self:setEnabled(false)
 	self.fogTrove:Destroy()
 	self.part:Destroy()
 end

--- a/src/Main/Photo/Tools/Background/MeshPartFogBackground.luau
+++ b/src/Main/Photo/Tools/Background/MeshPartFogBackground.luau
@@ -31,7 +31,7 @@ function MeshPartFogBackgroundClass.new(parent: Instance): MeshPartFogBackground
 	self.fogTrove = Trove.new()
 
 	self:SetEnabled(false)
-	self:_update()
+	self:Render()
 
 	return self
 end
@@ -77,14 +77,14 @@ function MeshPartFogBackgroundClass._createInstances(_self: MeshPartFogBackgroun
 	return part, mesh
 end
 
-function MeshPartFogBackgroundClass._update(self: MeshPartFogBackground)
+-- Public
+
+function MeshPartFogBackgroundClass.Render(self: MeshPartFogBackground)
 	local cameraCF = workspace.CurrentCamera.CFrame
 	local intersection = getBoundsIntersection(cameraCF)
 	self.part.CFrame = CFrame.new(intersection) * cameraCF.Rotation
 	self.fogDistance = -cameraCF:PointToObjectSpace(intersection).Z - MARGIN_OF_ERROR_DISTANCE
 end
-
--- Public
 
 function MeshPartFogBackgroundClass.SetEnabled(self: MeshPartFogBackground, enabled: boolean)
 	self.part.Transparency = if enabled then 0 else 1

--- a/src/Main/Photo/Tools/Blackout.luau
+++ b/src/Main/Photo/Tools/Blackout.luau
@@ -1,0 +1,54 @@
+local RunService = game:GetService("RunService") :: RunService
+
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local Trove = require(pluginRoot.Packages.Trove)
+
+local MeshPartFogBackground = require(script.Parent.Background.MeshPartFogBackground)
+
+local Blackout = {}
+
+local isDisabled = true
+local disabledByKey = {}
+local blackoutTrove = Trove.new()
+
+-- Private
+
+local function refresh()
+	local newIsDisabled = not not next(disabledByKey)
+
+	if newIsDisabled ~= isDisabled then
+		isDisabled = newIsDisabled
+		blackoutTrove:Clean()
+
+		if not isDisabled then
+			local background = MeshPartFogBackground.new(workspace.CurrentCamera)
+			background:SetColor(Color3.new(0, 0, 0))
+			background:SetEnabled(true)
+
+			blackoutTrove:Add(function()
+				background:Destroy()
+			end)
+
+			blackoutTrove:Add(RunService.RenderStepped:Connect(function()
+				background:Render()
+			end))
+		end
+	end
+end
+
+-- Public
+
+function Blackout.isEnabled()
+	return not isDisabled
+end
+
+function Blackout.setDisabled(key: string, disabled: boolean)
+	disabledByKey[key] = if disabled then true else nil
+	refresh()
+end
+
+--
+
+Blackout.setDisabled("default", true)
+
+return Blackout

--- a/src/Main/Photo/Tools/Blackout.luau
+++ b/src/Main/Photo/Tools/Blackout.luau
@@ -22,15 +22,15 @@ local function refresh()
 
 		if not isDisabled then
 			local background = MeshPartFogBackground.new(workspace.CurrentCamera)
-			background:SetColor(Color3.new(0, 0, 0))
-			background:SetEnabled(true)
+			background:setColor(Color3.new(0, 0, 0))
+			background:setEnabled(true)
 
 			blackoutTrove:Add(function()
 				background:Destroy()
 			end)
 
 			blackoutTrove:Add(RunService.RenderStepped:Connect(function()
-				background:Render()
+				background:render()
 			end))
 		end
 	end

--- a/src/Main/Photo/init.luau
+++ b/src/Main/Photo/init.luau
@@ -13,6 +13,7 @@ local Types = require(pluginRoot.Main.Bindings.Interface.Types)
 local State = require(pluginRoot.Main.State)
 
 local SceneControl = require(script.SceneControl)
+local Blackout = require(script.Tools.Blackout)
 local Captures = require(script.Captures)
 
 local Photo = {}
@@ -129,6 +130,8 @@ function Photo.captureViewport(options: Types.CaptureViewportOptions)
 		task.wait(options.delay)
 	end
 
+	Blackout.setDisabled("capturing", true)
+
 	local results: { Image.Image }
 	local trove = createIsCapturingTrove()
 	local success, err = SceneControl.freeze(true, function()
@@ -136,6 +139,7 @@ function Photo.captureViewport(options: Types.CaptureViewportOptions)
 	end)
 
 	trove:Destroy()
+	Blackout.setDisabled("capturing", false)
 
 	if not success then
 		if err then

--- a/src/Main/State/init.luau
+++ b/src/Main/State/init.luau
@@ -19,7 +19,7 @@ local function defaultTemporary()
 
 		isCapturing = false,
 		isFullscreen = false,
-		isBlackout = false,
+		isBlackoutMode = false,
 		isExperimentalMode = false,
 
 		uiCaptureTypeIndex = 1,

--- a/src/Main/State/init.luau
+++ b/src/Main/State/init.luau
@@ -19,6 +19,7 @@ local function defaultTemporary()
 
 		isCapturing = false,
 		isFullscreen = false,
+		isBlackout = false,
 		isExperimentalMode = false,
 
 		uiCaptureTypeIndex = 1,

--- a/src/Main/UserInterface/Components/Gallery/ConfigurationWindow/init.luau
+++ b/src/Main/UserInterface/Components/Gallery/ConfigurationWindow/init.luau
@@ -181,7 +181,27 @@ local function ViewportGroup(props: GroupsProps)
 		HorizontalSplit = HORIZONTAL_SPLIT,
 		Title = "Viewport",
 		List = {
-
+			{
+				Name = "Blackout Mode",
+				Node = React.createElement(React.Fragment, {}, {
+					Padding = React.createElement("UIPadding", {
+						PaddingLeft = UDim.new(0, 5),
+						PaddingRight = UDim.new(0, 5),
+						PaddingTop = UDim.new(0, 4),
+						PaddingBottom = UDim.new(0, 4),
+					}),
+					Checkbox = React.createElement(StudioComponents.Checkbox, {
+						Disabled = props.RootProps.Disabled,
+						Size = UDim2.fromScale(1, 1),
+						Value = props.State.temporary.isBlackoutMode,
+						OnChanged = function()
+							props.MutateState(function(state)
+								state.temporary.isBlackoutMode = not state.temporary.isBlackoutMode
+							end)
+						end,
+					}),
+				}),
+			},
 			{
 				Name = "Fullscreen",
 				Node = React.createElement(React.Fragment, {}, {
@@ -198,27 +218,6 @@ local function ViewportGroup(props: GroupsProps)
 						OnChanged = function()
 							props.MutateState(function(state)
 								state.temporary.isFullscreen = not state.temporary.isFullscreen
-							end)
-						end,
-					}),
-				}),
-			},
-			{
-				Name = "Blackout",
-				Node = React.createElement(React.Fragment, {}, {
-					Padding = React.createElement("UIPadding", {
-						PaddingLeft = UDim.new(0, 5),
-						PaddingRight = UDim.new(0, 5),
-						PaddingTop = UDim.new(0, 4),
-						PaddingBottom = UDim.new(0, 4),
-					}),
-					Checkbox = React.createElement(StudioComponents.Checkbox, {
-						Disabled = props.RootProps.Disabled,
-						Size = UDim2.fromScale(1, 1),
-						Value = props.State.temporary.isBlackout,
-						OnChanged = function()
-							props.MutateState(function(state)
-								state.temporary.isBlackout = not state.temporary.isBlackout
 							end)
 						end,
 					}),

--- a/src/Main/UserInterface/Components/Gallery/ConfigurationWindow/init.luau
+++ b/src/Main/UserInterface/Components/Gallery/ConfigurationWindow/init.luau
@@ -181,6 +181,7 @@ local function ViewportGroup(props: GroupsProps)
 		HorizontalSplit = HORIZONTAL_SPLIT,
 		Title = "Viewport",
 		List = {
+
 			{
 				Name = "Fullscreen",
 				Node = React.createElement(React.Fragment, {}, {
@@ -197,6 +198,27 @@ local function ViewportGroup(props: GroupsProps)
 						OnChanged = function()
 							props.MutateState(function(state)
 								state.temporary.isFullscreen = not state.temporary.isFullscreen
+							end)
+						end,
+					}),
+				}),
+			},
+			{
+				Name = "Blackout",
+				Node = React.createElement(React.Fragment, {}, {
+					Padding = React.createElement("UIPadding", {
+						PaddingLeft = UDim.new(0, 5),
+						PaddingRight = UDim.new(0, 5),
+						PaddingTop = UDim.new(0, 4),
+						PaddingBottom = UDim.new(0, 4),
+					}),
+					Checkbox = React.createElement(StudioComponents.Checkbox, {
+						Disabled = props.RootProps.Disabled,
+						Size = UDim2.fromScale(1, 1),
+						Value = props.State.temporary.isBlackout,
+						OnChanged = function()
+							props.MutateState(function(state)
+								state.temporary.isBlackout = not state.temporary.isBlackout
 							end)
 						end,
 					}),

--- a/src/Main/UserInterface/init.luau
+++ b/src/Main/UserInterface/init.luau
@@ -353,10 +353,10 @@ function UserInterface.mountGallery(plugin: Plugin, toolbar: PluginToolbar)
 end
 
 function UserInterface.mountBlackout(plugin: Plugin)
-	Blackout.setDisabled("default", not State.read().temporary.isBlackout)
+	Blackout.setDisabled("default", not State.read().temporary.isBlackoutMode)
 	local disconnect = State.onChanged(function(path)
-		if path[1] == "temporary" and path[2] == "isBlackout" then
-			Blackout.setDisabled("default", not State.read().temporary.isBlackout)
+		if path[1] == "temporary" and path[2] == "isBlackoutMode" then
+			Blackout.setDisabled("default", not State.read().temporary.isBlackoutMode)
 		end
 	end)
 

--- a/src/Main/UserInterface/init.luau
+++ b/src/Main/UserInterface/init.luau
@@ -19,8 +19,9 @@ local State = require(pluginRoot.Main.State)
 local Photo = require(pluginRoot.Main.Photo)
 
 local RenderRect = require(pluginRoot.Main.Bindings.Interface.Helpers.RenderRect)
-local Captures = require(pluginRoot.Main.Photo.Captures)
+local Blackout = require(pluginRoot.Main.Photo.Tools.Blackout)
 local UIHider = require(pluginRoot.Main.Photo.Tools.UIHider)
+local Captures = require(pluginRoot.Main.Photo.Captures)
 
 local Hooks = require(script.Hooks)
 local Icons = require(script.Icons)
@@ -348,6 +349,19 @@ function UserInterface.mountGallery(plugin: Plugin, toolbar: PluginToolbar)
 
 	plugin.Unloading:Connect(function()
 		dockRoot:unmount()
+	end)
+end
+
+function UserInterface.mountBlackout(plugin: Plugin)
+	Blackout.setDisabled("default", not State.read().temporary.isBlackout)
+	local disconnect = State.onChanged(function(path)
+		if path[1] == "temporary" and path[2] == "isBlackout" then
+			Blackout.setDisabled("default", not State.read().temporary.isBlackout)
+		end
+	end)
+
+	plugin.Unloading:Connect(function()
+		disconnect()
 	end)
 end
 


### PR DESCRIPTION
# Problem

One of the easiest ways to get a good sense of your final capture is to use a black background for contrast. This however can be a problem b/c black skyboxes influence the scene which may impact what you're trying to capture. Additionally, the added friction of dragging skyboxes in and out of lighting kind of sucks.

# Solution

This PR introduces a new setting called "Blackout Mode". It renders a non-skybox black background when turned on making it super easy to get the contrast you'd want without the hassle. This makes it way easier to see how thing that get influenced heavily by their background will actually capture with photobooth.

https://github.com/user-attachments/assets/e846d84b-6545-4d97-a07f-ba106c44a04b

