### PR TITLE
Switch image viewer to pixelated resampler

### DIFF
--- a/src/Main/UserInterface/Components/Gallery/ImageInterface/ImageViewer/DisplayImage/HighResImageSplit.luau
+++ b/src/Main/UserInterface/Components/Gallery/ImageInterface/ImageViewer/DisplayImage/HighResImageSplit.luau
@@ -11,6 +11,7 @@ export type Props = {
 	AnchorPoint: Vector2,
 
 	EditableImage: EditableImage,
+	ResampleMode: Enum.ResamplerMode,
 }
 
 local function useHighResSplit(sourceEditableImage: EditableImage)
@@ -95,7 +96,7 @@ local function HighResImageSplit(props: Props)
 
 		labels[`ImageSplit{i}`] = React.createElement("ImageLabel", {
 			ImageContent = Content.fromObject(splitEntry.EditableImage),
-			ResampleMode = Enum.ResamplerMode.Pixelated,
+			ResampleMode = props.ResampleMode,
 			Position = UDim2.fromScale(uvPosition.X, uvPosition.Y),
 			Size = UDim2.fromScale(uvSize.X, uvSize.Y),
 			BackgroundTransparency = 1,

--- a/src/Main/UserInterface/Components/Gallery/ImageInterface/ImageViewer/DisplayImage/HighResImageSplit.luau
+++ b/src/Main/UserInterface/Components/Gallery/ImageInterface/ImageViewer/DisplayImage/HighResImageSplit.luau
@@ -95,6 +95,7 @@ local function HighResImageSplit(props: Props)
 
 		labels[`ImageSplit{i}`] = React.createElement("ImageLabel", {
 			ImageContent = Content.fromObject(splitEntry.EditableImage),
+			ResampleMode = Enum.ResamplerMode.Pixelated,
 			Position = UDim2.fromScale(uvPosition.X, uvPosition.Y),
 			Size = UDim2.fromScale(uvSize.X, uvSize.Y),
 			BackgroundTransparency = 1,

--- a/src/Main/UserInterface/Components/Gallery/ImageInterface/ImageViewer/DisplayImage/init.luau
+++ b/src/Main/UserInterface/Components/Gallery/ImageInterface/ImageViewer/DisplayImage/init.luau
@@ -81,6 +81,12 @@ local function DisplayImage(props: Props)
 	local imageLayerSize = UDim2.fromScale(zoom * fitScale.X, zoom * fitScale.Y)
 	local imageLayerPosition = UDim2.fromScale(imageCenter.X, imageCenter.Y)
 
+	-- Only show exact pixels (Pixelated) once the image is displayed at or above its native
+	-- resolution, i.e. the user is zooming in. Below 100% the image is being downscaled to fit the
+	-- window, where Default resampling looks better.
+	--local resampleMode = if controls.trueScale >= 1 then Enum.ResamplerMode.Pixelated else Enum.ResamplerMode.Default
+	local resampleMode = Enum.ResamplerMode.Default
+
 	return React.createElement("Frame", {
 		BackgroundTransparency = 1,
 		Size = UDim2.fromScale(1, 1),
@@ -150,6 +156,7 @@ local function DisplayImage(props: Props)
 					AnchorPoint = Vector2.new(0, 0),
 
 					EditableImage = props.EditableImage,
+					ResampleMode = resampleMode,
 				}),
 
 				AttachedDimensions = React.createElement("TextLabel", {

--- a/src/Main/UserInterface/Components/Gallery/ImageInterface/useImageControls.luau
+++ b/src/Main/UserInterface/Components/Gallery/ImageInterface/useImageControls.luau
@@ -13,6 +13,7 @@ export type ImageControls = {
 	zoom: number,
 	imageCenter: Vector2,
 	fitScale: Vector2,
+	trueScale: number,
 	maxZoom: number,
 	hasImage: boolean,
 	reset: () -> (),
@@ -79,6 +80,10 @@ local function useImageControls(editableImage: EditableImage?, viewportRef: { cu
 	local centerRef = React.useRef(imageCenter)
 	local viewportSizeRef = React.useRef(viewportSize)
 	local fitScaleRef = React.useRef(fitScale)
+
+	local trueScale = if imageSize.X > 0 and viewportSize.X > 0
+		then zoom * fitScale.X * viewportSize.X / imageSize.X
+		else zoom
 
 	zoomRef.current = zoom
 	centerRef.current = imageCenter
@@ -181,6 +186,7 @@ local function useImageControls(editableImage: EditableImage?, viewportRef: { cu
 		zoom = zoom,
 		imageCenter = imageCenter,
 		fitScale = fitScale,
+		trueScale = trueScale,
 		maxZoom = maxZoom,
 		hasImage = editableImage ~= nil,
 		reset = reset,


### PR DESCRIPTION
# Problem

The image viewer uses bilinear filtering which means when you zoom in you get blurry blown up pixels.

# Solution

Switching the resampler to pixelated gives the intended effect. The pixels remain clean cut even when heavily zoomed in.

Not sure if I will merge this or not - technically when the image is shrunk to fix smaller windows this could have negative impacts. I  might need to switch it when zoom > 1

Update: I added the code to handle the switch when zoom > 1, but I found it didn't look great. I'm keeping the code in, but forcing the default filter-mode so effectively no change.