### PR TITLE
Add binding rect request

### DIFF
--- a/src/Main/Bindings/Interface/src/Binding/init.luau
+++ b/src/Main/Bindings/Interface/src/Binding/init.luau
@@ -28,7 +28,9 @@ local function tryConnecting()
 		local connectBinding = camera and camera:FindFirstChild("ConnectBinding") :: BindableFunction?
 
 		if connectBinding then
-			connectBinding:Invoke(script.Parent)
+			pcall(function()
+				connectBinding:Invoke(script.Parent)
+			end)
 		end
 	end
 end
@@ -43,14 +45,19 @@ end
 function Binding.invoke<T..., U...>(identifier: string, ...: T...): U...
 	tryConnecting()
 
-	local results = table.pack(bindable:Invoke(identifier, ...))
-	local success = table.unpack(results, 1, 1)
+	local invokeResults = table.pack(pcall(bindable.Invoke, bindable, identifier, ...))
 
-	if not success then
-		error(table.unpack(results, 2, 2), 2)
+	local invokeSuccess = invokeResults[1]
+	if not invokeSuccess then
+		error(invokeResults[2], 2)
 	end
 
-	return table.unpack(results, 2)
+	local success = invokeResults[2]
+	if not success then
+		error(invokeResults[3], 2)
+	end
+
+	return table.unpack(invokeResults, 3, invokeResults.n)
 end
 
 return Binding

--- a/src/Main/Bindings/Interface/src/Types.luau
+++ b/src/Main/Bindings/Interface/src/Types.luau
@@ -19,4 +19,9 @@ export type CaptureUIOptions = {
 	alphaBleed: boolean?,
 }
 
+export type RequestRectOptions = {
+	rect: Rect?,
+	scale: Vector2?,
+}
+
 return {}

--- a/src/Main/Bindings/Interface/src/init.luau
+++ b/src/Main/Bindings/Interface/src/init.luau
@@ -54,8 +54,39 @@ function Bindings.captureUI(options: CaptureUIOptions): MeshPart?
 	return Binding.invoke("captureUI", options)
 end
 
-function Bindings.requestRect(options: RequestRectOptions): Rect?
-	return Binding.invoke("requestRect", options)
+function Bindings.requestRect(options: RequestRectOptions)
+	local guid: string = Binding.invoke("requestRect", {
+		type = "request",
+		rect = options.rect,
+		scale = options.scale,
+	})
+
+	local cachedResult
+	local resolvedExpect = false
+	local resolvedCancel = false
+
+	local function expect()
+		if not resolvedExpect and not resolvedCancel then
+			resolvedExpect = true
+			cachedResult = Binding.invoke("requestRect", {
+				type = "expect",
+				guid = guid,
+			}) :: Rect?
+		end
+		return cachedResult
+	end
+
+	local function cancel()
+		if not resolvedCancel then
+			resolvedCancel = true
+			Binding.invoke("requestRect", {
+				type = "cancel",
+				guid = guid,
+			})
+		end
+	end
+
+	return expect, cancel
 end
 
 function Bindings.isConnected(): boolean

--- a/src/Main/Bindings/Interface/src/init.luau
+++ b/src/Main/Bindings/Interface/src/init.luau
@@ -14,6 +14,8 @@ export type ViewportCaptureTypes = Types.ViewportCaptureTypes
 export type CaptureViewportOptions = Types.CaptureViewportOptions
 export type CaptureUIOptions = Types.CaptureUIOptions
 
+export type RequestRectOptions = Types.RequestRectOptions
+
 -- Public
 
 Bindings.rect = RenderRect
@@ -50,6 +52,10 @@ end
 
 function Bindings.captureUI(options: CaptureUIOptions): MeshPart?
 	return Binding.invoke("captureUI", options)
+end
+
+function Bindings.requestRect(options: RequestRectOptions): Rect?
+	return Binding.invoke("requestRect", options)
 end
 
 function Bindings.isConnected(): boolean

--- a/src/Main/Bindings/Invocations/RequestRect.luau
+++ b/src/Main/Bindings/Invocations/RequestRect.luau
@@ -35,7 +35,7 @@ local function callback(options: typeof(gtOptions))
 	if options.type == "request" then
 		local castedOptions = options :: typeof(requestOptions)
 		local guid = HttpService:GenerateGUID(false)
-		UserInterface.rectRequest(guid, castedOptions.rect, castedOptions.scale)
+		UserInterface.requestRect(guid, castedOptions.rect, castedOptions.scale)
 		return guid
 	end
 

--- a/src/Main/Bindings/Invocations/RequestRect.luau
+++ b/src/Main/Bindings/Invocations/RequestRect.luau
@@ -1,0 +1,24 @@
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local gt = require(pluginRoot.Packages.GreenTea)
+
+local UserInterface = require(pluginRoot.Main.UserInterface)
+
+local gtOptions = gt.table({
+	rect = gt.opt(gt.Rect()),
+	scale = gt.opt(gt.Vector2()),
+})
+
+-- stylua: ignore
+local typechecker = gt.fn(
+	gt.args(gtOptions),
+	gt.returns(gt.opt(gt.Rect()))
+)
+
+local function callback(options: typeof(gtOptions))
+	return UserInterface.rectRequest(options.rect, options.scale)
+end
+
+return {
+	identifier = "requestRect",
+	callback = gt.wrapFn(typechecker, callback),
+}

--- a/src/Main/Bindings/Invocations/RequestRect.luau
+++ b/src/Main/Bindings/Invocations/RequestRect.luau
@@ -15,7 +15,8 @@ local typechecker = gt.fn(
 )
 
 local function callback(options: typeof(gtOptions))
-	return UserInterface.rectRequest(options.rect, options.scale)
+	local request = UserInterface.rectRequest(options.rect, options.scale)
+	return request.expect()
 end
 
 return {

--- a/src/Main/Bindings/Invocations/RequestRect.luau
+++ b/src/Main/Bindings/Invocations/RequestRect.luau
@@ -1,22 +1,55 @@
+local HttpService = game:GetService("HttpService")
+
 local pluginRoot = script:FindFirstAncestor("PluginRoot")
 local gt = require(pluginRoot.Packages.GreenTea)
 
 local UserInterface = require(pluginRoot.Main.UserInterface)
 
-local gtOptions = gt.table({
+local strLimited = gt.string({ bytes = 200 })
+
+local requestOptions = gt.table({
+	type = gt.literal("request"),
 	rect = gt.opt(gt.Rect()),
 	scale = gt.opt(gt.Vector2()),
 })
 
+local expectOptions = gt.table({
+	type = gt.literal("expect"),
+	guid = strLimited,
+})
+
+local cancelOptions = gt.table({
+	type = gt.literal("cancel"),
+	guid = strLimited,
+})
+
+local gtOptions = gt.union(requestOptions, expectOptions, cancelOptions)
+
 -- stylua: ignore
 local typechecker = gt.fn(
 	gt.args(gtOptions),
-	gt.returns(gt.opt(gt.Rect()))
+	gt.returns(gt.opt(gt.union(strLimited, gt.Rect())))
 )
 
 local function callback(options: typeof(gtOptions))
-	local request = UserInterface.rectRequest(options.rect, options.scale)
-	return request.expect()
+	if options.type == "request" then
+		local castedOptions = options :: typeof(requestOptions)
+		local guid = HttpService:GenerateGUID(false)
+		UserInterface.rectRequest(guid, castedOptions.rect, castedOptions.scale)
+		return guid
+	end
+
+	local castedOptions = options :: typeof(expectOptions) | typeof(cancelOptions)
+	local control = UserInterface.getRectRequestByGuid(castedOptions.guid)
+	if control then
+		if options.type == "expect" then
+			return control.expect()
+		elseif options.type == "cancel" then
+			return control.cancel()
+		end
+	end
+
+	return nil
 end
 
 return {

--- a/src/Main/Bindings/init.luau
+++ b/src/Main/Bindings/init.luau
@@ -35,10 +35,10 @@ local function connectBindings(plugin: Plugin, interface: Instance)
 
 	if bindable then
 		bindable.OnInvoke = function(identifier: string, ...: any)
-			local resultFuture = Future.new() :: Future.Future<boolean, string?, { any }>
+			local resultFuture = Future.new() :: Future.Future<boolean, string?, boolean, { any }>
 			local connection = plugin.Unloading:Connect(function()
 				if not resultFuture:isCompleted() then
-					resultFuture:complete(false, "Plugin unloaded.", {})
+					resultFuture:complete(false, "Plugin unloaded.", true, {})
 				end
 			end)
 
@@ -52,13 +52,15 @@ local function connectBindings(plugin: Plugin, interface: Instance)
 				end)
 
 				if not resultFuture:isCompleted() then
-					resultFuture:complete(success, err, results)
+					resultFuture:complete(success, err, false, results)
 				end
 			end)
 
-			local success, err, results = resultFuture:expect()
-			task.cancel(thread)
+			local success, err, unloaded, results = resultFuture:expect()
 			connection:Disconnect()
+			if unloaded then
+				task.cancel(thread)
+			end
 
 			if success then
 				return true, table.unpack(results)

--- a/src/Main/Bindings/init.luau
+++ b/src/Main/Bindings/init.luau
@@ -2,6 +2,7 @@ local CaptureService = game:GetService("CaptureService") :: CaptureService
 local ServerStorage = game:GetService("ServerStorage") :: ServerStorage
 
 local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local Future = require(pluginRoot.Packages.Future)
 local Trove = require(pluginRoot.Packages.Trove)
 
 local StateManager = require(pluginRoot.Main.StateManager)
@@ -34,12 +35,30 @@ local function connectBindings(plugin: Plugin, interface: Instance)
 
 	if bindable then
 		bindable.OnInvoke = function(identifier: string, ...: any)
-			local results
-			local packedArgs = table.pack(...)
-			local success, err = pcall(function()
-				local invocation = assert(invocationByIdentifier[identifier], `No invocation found for: {identifier}`)
-				results = table.pack(invocation.callback(table.unpack(packedArgs)))
+			local resultFuture = Future.new() :: Future.Future<boolean, string?, { any }>
+			local connection = plugin.Unloading:Connect(function()
+				if not resultFuture:isCompleted() then
+					resultFuture:complete(false, "Plugin unloaded.", {})
+				end
 			end)
+
+			local packedArgs = table.pack(...)
+			local thread = task.spawn(function()
+				local results = {}
+				local success, err = pcall(function()
+					local invocation =
+						assert(invocationByIdentifier[identifier], `No invocation found for: {identifier}`)
+					results = table.pack(invocation.callback(table.unpack(packedArgs)))
+				end)
+
+				if not resultFuture:isCompleted() then
+					resultFuture:complete(success, err, results)
+				end
+			end)
+
+			local success, err, results = resultFuture:expect()
+			task.cancel(thread)
+			connection:Disconnect()
 
 			if success then
 				return true, table.unpack(results)

--- a/src/Main/StateManager/ObservableValue.luau
+++ b/src/Main/StateManager/ObservableValue.luau
@@ -41,19 +41,22 @@ function ObservableValueClass.update<T>(self: ObservableValue<T>)
 	end
 end
 
-function ObservableValueClass.use<T>(self: ObservableValue<T>)
+local function useInternal<T, U>(self: ObservableValue<T>, read: (T) -> U, predicate: (U, U) -> boolean)
 	local state, setState = React.useState({})
-	local valueRef = React.useRef(self.value)
+	local valueRef = React.useRef(read(self.value))
 
 	React.useEffect(function()
-		if valueRef.current ~= self.value then
-			valueRef.current = self.value
-			setState({})
+		local function refresh()
+			local readValue = read(self.value)
+			if predicate(readValue, valueRef.current) then
+				valueRef.current = readValue
+				setState({})
+			end
 		end
 
+		refresh()
 		local connection = self.signal:Connect(function()
-			valueRef.current = self.value
-			setState({})
+			refresh()
 		end)
 
 		return function()
@@ -61,39 +64,31 @@ function ObservableValueClass.use<T>(self: ObservableValue<T>)
 		end
 	end, { self :: any })
 
-	local updateValue = React.useCallback(function(callback: (T) -> T)
-		self:update()(callback)
-	end, { self :: any, state :: any })
-
-	return valueRef.current, updateValue
+	return valueRef.current, state
 end
 
 function ObservableValueClass.useSpecific<T>(self: ObservableValue<T>)
 	return function<U>(read: (T) -> U)
-		local _state, setState = React.useState({})
-		local valueRef = React.useRef(read(self.value))
+		local value = useInternal(self, read, function(new, prev)
+			return new ~= prev
+		end)
 
-		React.useEffect(function()
-			local function refresh()
-				local readValue = read(self.value)
-				if valueRef.current ~= readValue then
-					valueRef.current = readValue
-					setState({})
-				end
-			end
-
-			refresh()
-			local connection = self.signal:Connect(function()
-				refresh()
-			end)
-
-			return function()
-				connection:Disconnect()
-			end
-		end, { self :: any })
-
-		return valueRef.current
+		return value
 	end
+end
+
+function ObservableValueClass.use<T>(self: ObservableValue<T>)
+	local value, state = useInternal(self, function(selfValue)
+		return selfValue
+	end, function(new, prev)
+		return true
+	end)
+
+	local updateValue = React.useCallback(function(callback: (T) -> T)
+		self:update()(callback)
+	end, { self :: any, state :: any })
+
+	return value, updateValue
 end
 
 function ObservableValueClass.onChanged<T>(self: ObservableValue<T>, callback: () -> ())

--- a/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/ActionBar.luau
+++ b/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/ActionBar.luau
@@ -7,6 +7,10 @@ local uiRoot = script:FindFirstAncestor("UserInterface")
 local BaseButton = require(uiRoot.Components.BaseButton)
 local Hooks = require(uiRoot.Hooks)
 
+local CAMERA_ICON = assert(Lucide.GetAsset("camera", 16))
+local MAXIMIZE_ICON = assert(Lucide.GetAsset("maximize", 16))
+local CIRCLE_CHECK_ICON = assert(Lucide.GetAsset("circle-check", 16))
+
 type Props = {
 	AnchorPoint: Vector2,
 	Position: UDim2,
@@ -20,6 +24,7 @@ type Props = {
 	UseRectText: boolean,
 	OnRectInput: (Rect) -> (),
 
+	IsRectRequest: boolean,
 	OnMaximize: () -> (),
 	OnCapture: () -> (boolean, string?),
 
@@ -183,8 +188,7 @@ end
 
 local function ActionBar(props: Props)
 	local theme = StudioComponents.useTheme()
-	local cameraIcon = assert(Lucide.GetAsset("camera", 16))
-	local maximizeIcon = assert(Lucide.GetAsset("maximize", 16))
+	local captureIcon = if props.IsRectRequest then CIRCLE_CHECK_ICON else CAMERA_ICON
 
 	local underFrameRef = React.useRef(nil)
 	local underFrameAbsPosition = Hooks.useRefProperty(underFrameRef, "AbsolutePosition", Vector2.zero)
@@ -254,11 +258,11 @@ local function ActionBar(props: Props)
 					TextColorStyle = Enum.StudioStyleGuideColor.ButtonText,
 
 					Icon = {
-						Image = maximizeIcon.Url,
-						RectSize = maximizeIcon.ImageRectSize,
-						RectOffset = maximizeIcon.ImageRectOffset,
+						Image = MAXIMIZE_ICON.Url,
+						RectSize = MAXIMIZE_ICON.ImageRectSize,
+						RectOffset = MAXIMIZE_ICON.ImageRectOffset,
 
-						Size = maximizeIcon.ImageRectSize,
+						Size = MAXIMIZE_ICON.ImageRectSize,
 						Transparency = if props.Disabled then 0.7 else 0,
 						UseThemeColor = true,
 					},
@@ -273,11 +277,11 @@ local function ActionBar(props: Props)
 					Size = UDim2.new(0, 24, 1, 0),
 
 					Icon = {
-						Image = cameraIcon.Url,
-						RectSize = cameraIcon.ImageRectSize,
-						RectOffset = cameraIcon.ImageRectOffset,
+						Image = captureIcon.Url,
+						RectSize = captureIcon.ImageRectSize,
+						RectOffset = captureIcon.ImageRectOffset,
 
-						Size = cameraIcon.ImageRectSize,
+						Size = captureIcon.ImageRectSize,
 						Transparency = if props.Disabled then 0.7 else 0,
 						Color = Color3.new(1, 1, 1),
 					},

--- a/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/CroppedViewport.story.luau
+++ b/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/CroppedViewport.story.luau
@@ -8,8 +8,20 @@ local CroppedViewport = require(script.Parent)
 
 return CreateStory.theme(function(props)
 	local isDisabled, setIsDisabled = React.useState(false)
+	local captureRectRef = React.useRef(Rect.new(0, 0, 512, 512))
 
 	return React.createElement(CroppedViewport, {
+		ScaleOS = Vector2.new(1, 1),
+		IsRectRequest = false,
+		CaptureRectRef = captureRectRef,
+
+		OnReady = function(viewport)
+			local absPosition = viewport.AbsolutePosition
+			local absSize = viewport.AbsoluteSize
+			local center = absPosition + absSize / 2
+			captureRectRef.current = Rect.new(center - absSize / 4, center + absSize / 4)
+		end,
+
 		OnMaximize = function()
 			print("Maximize")
 		end,

--- a/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/CroppedViewport.story.luau
+++ b/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/CroppedViewport.story.luau
@@ -9,11 +9,15 @@ local CroppedViewport = require(script.Parent)
 return CreateStory.theme(function(props)
 	local isDisabled, setIsDisabled = React.useState(false)
 	local captureRectRef = React.useRef(Rect.new(0, 0, 512, 512))
+	local updateCaptureRectRef = React.useCallback(function(rect: Rect)
+		captureRectRef.current = rect
+	end, {})
 
 	return React.createElement(CroppedViewport, {
 		ScaleOS = Vector2.new(1, 1),
 		IsRectRequest = false,
 		CaptureRectRef = captureRectRef,
+		UpdateCaptureRectRef = updateCaptureRectRef,
 
 		OnReady = function(viewport)
 			local absPosition = viewport.AbsolutePosition

--- a/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/init.luau
@@ -173,7 +173,12 @@ local function useScaledViewportRect(viewportRect: Rect, scaleOS: Vector2)
 	return scaledViewportRect
 end
 
-local function useCaptureRect(captureRef: { current: Rect }, scaledViewportRect: Rect, scaleOS: Vector2)
+local function useCaptureRect(
+	captureRef: { current: Rect },
+	updateCaptureRef: (Rect) -> (),
+	scaledViewportRect: Rect,
+	scaleOS: Vector2
+)
 	local getClampedCaptureRect = React.useCallback(
 		function(rect: Rect, direction: Vector2, delta: Vector2, mirror: boolean, clampMin: boolean)
 			return clampRect(rect, scaledViewportRect, scaleOS, direction, delta * scaleOS, mirror, clampMin)
@@ -184,6 +189,12 @@ local function useCaptureRect(captureRef: { current: Rect }, scaledViewportRect:
 	local captureRect, setCaptureRect = React.useState(
 		RenderRect.fromRect(getClampedCaptureRect(captureRef.current, Vector2.zero, Vector2.zero, true, true))
 	)
+
+	React.useEffect(function()
+		setCaptureRect(
+			RenderRect.fromRect(getClampedCaptureRect(captureRef.current, Vector2.zero, Vector2.zero, true, true))
+		)
+	end, { updateCaptureRef })
 
 	local setCaptureRectClamped = React.useCallback(
 		function(rect: Rect, direction: Vector2, delta: Vector2, mirror: boolean, clampMin: boolean)
@@ -205,17 +216,19 @@ local function useCaptureRect(captureRef: { current: Rect }, scaledViewportRect:
 end
 
 export type Props = {
+	ScaleOS: Vector2,
+	IsRectRequest: boolean,
+	CaptureRectRef: { current: Rect },
+	UpdateCaptureRectRef: (Rect) -> (),
 	OnCapture: (Rect) -> (boolean, string?),
 	OnMaximize: () -> (),
+	OnReady: (GuiObject) -> ()?,
 	Visible: boolean,
 	Disabled: boolean?,
 }
 
-local function CroppedViewport(props: Props & { ViewportRect: Rect, CaptureRectRef: { current: Rect } })
+local function CroppedViewport(props: Props & { ViewportRect: Rect })
 	local theme = StudioComponents.useTheme()
-	local scaleOS = StateManager.temporary:useSpecific()(function(state)
-		return state.scaleOS
-	end)
 
 	local isCropMode, setIsCropMode = React.useState(false)
 	local isCropDragging, setIsCropDragging = React.useState(false)
@@ -226,15 +239,16 @@ local function CroppedViewport(props: Props & { ViewportRect: Rect, CaptureRectR
 	local dragPositionRef = React.useRef(Vector2.zero)
 	local dragRectRef = React.useRef(Rect.new(0, 0, 0, 0))
 
-	local scaledViewportRect = useScaledViewportRect(props.ViewportRect, scaleOS)
-	local captureRect, setCaptureRect = useCaptureRect(props.CaptureRectRef, scaledViewportRect, scaleOS)
+	local scaledViewportRect = useScaledViewportRect(props.ViewportRect, props.ScaleOS)
+	local captureRect, setCaptureRect =
+		useCaptureRect(props.CaptureRectRef, props.UpdateCaptureRectRef, scaledViewportRect, props.ScaleOS)
 
 	local renderedCaptureRect = RenderRect.fromRect(
 		Rect.new(
-			captureRect.Min.X / scaleOS.X,
-			captureRect.Min.Y / scaleOS.Y,
-			captureRect.Max.X / scaleOS.X,
-			captureRect.Max.Y / scaleOS.Y
+			captureRect.Min.X / props.ScaleOS.X,
+			captureRect.Min.Y / props.ScaleOS.Y,
+			captureRect.Max.X / props.ScaleOS.X,
+			captureRect.Max.Y / props.ScaleOS.Y
 		)
 	)
 
@@ -335,6 +349,7 @@ local function CroppedViewport(props: Props & { ViewportRect: Rect, CaptureRectR
 					setCaptureRect(rect, Vector2.zero, Vector2.zero, false, false)
 				end,
 
+				IsRectRequest = props.IsRectRequest,
 				OnMaximize = props.OnMaximize,
 				OnCapture = function()
 					return props.OnCapture(captureRect)
@@ -421,8 +436,6 @@ local function CroppedViewport(props: Props & { ViewportRect: Rect, CaptureRectR
 end
 
 return function(props: Props)
-	local captureRectRef = React.useRef(Rect.new(0, 0, 512, 512))
-
 	local viewportRef = React.useRef(nil :: GuiObject?)
 	local viewportAbsSize = Hooks.useRefProperty(viewportRef, "AbsoluteSize", Vector2.new(math.huge, math.huge))
 	local viewportAbsPosition = Hooks.useRefProperty(viewportRef, "AbsolutePosition", Vector2.zero)
@@ -436,20 +449,10 @@ return function(props: Props)
 
 	local isReady, setIsReady = React.useState(false)
 	React.useEffect(function()
-		local viewportFrame = viewportRef.current
-		if viewportFrame then
-			local scaleOS = StateManager.temporary:get().scaleOS
-			local absSize = viewportFrame.AbsoluteSize
-			local absPosition = viewportFrame.AbsolutePosition
-
-			local scaledViewportRect = RenderRect.fromAbs(absPosition * scaleOS, absSize * scaleOS)
-			local centerRect = scaleRect(scaledViewportRect, Vector2.new(0.5, 0.5), Vector2.new(0.5, 0.5))
-
-			-- we are setting the initial capture rect ref to be half the viewport from the center of the screen
-			captureRectRef.current = RenderRect.fromRect(centerRect)
-
-			setIsReady(true)
+		if props.OnReady and viewportRef.current then
+			props.OnReady(viewportRef.current)
 		end
+		setIsReady(true)
 	end, {})
 
 	return React.createElement("Frame", {
@@ -459,8 +462,11 @@ return function(props: Props)
 		ref = viewportRef,
 	}, {
 		Core = props.Visible and isReady and React.createElement(CroppedViewport, {
+			ScaleOS = props.ScaleOS,
+			IsRectRequest = props.IsRectRequest,
 			ViewportRect = viewportRect,
-			CaptureRectRef = captureRectRef,
+			CaptureRectRef = props.CaptureRectRef,
+			UpdateCaptureRectRef = props.UpdateCaptureRectRef,
 			OnMaximize = props.OnMaximize,
 			OnCapture = props.OnCapture,
 			Visible = props.Visible :: boolean,

--- a/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/init.luau
@@ -56,12 +56,6 @@ local MIN_CAPTURE_WIDTH = math.max(MIN_CAPTURE_HEIGHT, ACTION_BAR.Width, ALIGN_B
 local MAX_CAPTURE_HEIGHT = Constants.MaxCaptureRectSize.Y
 local MAX_CAPTURE_WIDTH = Constants.MaxCaptureRectSize.X
 
-local function scaleRect(rect: Rect, anchorPoint: Vector2, scale: Vector2)
-	local size = Vector2.new(rect.Width, rect.Height)
-	local anchor = rect.Min + size * anchorPoint
-	return Rect.new(rect.Min + (anchor - rect.Min) * scale, rect.Max + (anchor - rect.Max) * scale)
-end
-
 local function positionRect(rect: Rect, anchorPoint: Vector2, position: Vector2)
 	local size = Vector2.new(rect.Width, rect.Height)
 	local anchor = rect.Min + size * anchorPoint
@@ -186,15 +180,10 @@ local function useCaptureRect(
 		{ scaledViewportRect, scaleOS } :: { any }
 	)
 
-	local captureRect, setCaptureRect = React.useState(
-		RenderRect.fromRect(getClampedCaptureRect(captureRef.current, Vector2.zero, Vector2.zero, true, true))
-	)
-
-	React.useEffect(function()
-		setCaptureRect(
-			RenderRect.fromRect(getClampedCaptureRect(captureRef.current, Vector2.zero, Vector2.zero, true, true))
-		)
-	end, { updateCaptureRef })
+	local captureRect, setCaptureRect = React.useState(function()
+		local clampedCaptureRect = getClampedCaptureRect(captureRef.current, Vector2.zero, Vector2.zero, true, true)
+		return RenderRect.fromRect(clampedCaptureRect)
+	end)
 
 	local setCaptureRectClamped = React.useCallback(
 		function(rect: Rect, direction: Vector2, delta: Vector2, mirror: boolean, clampMin: boolean)
@@ -206,11 +195,18 @@ local function useCaptureRect(
 		{ getClampedCaptureRect }
 	)
 
+	local updateCaptureRefRef = React.useRef((nil :: any) :: typeof(updateCaptureRef))
 	React.useEffect(function()
-		local newCenter = scaledViewportRect.Min + Vector2.new(scaledViewportRect.Width, scaledViewportRect.Height) / 2
-		local newCaptureRect = positionRect(captureRect, Vector2.new(0.5, 0.5), newCenter)
-		setCaptureRectClamped(newCaptureRect, Vector2.zero, Vector2.zero, true, true)
-	end, { setCaptureRectClamped })
+		if updateCaptureRefRef.current ~= updateCaptureRef then
+			updateCaptureRefRef.current = updateCaptureRef
+			setCaptureRectClamped(captureRef.current, Vector2.zero, Vector2.zero, true, true)
+		else
+			local newCenter = scaledViewportRect.Min
+				+ Vector2.new(scaledViewportRect.Width, scaledViewportRect.Height) / 2
+			local newCaptureRect = positionRect(captureRect, Vector2.new(0.5, 0.5), newCenter)
+			setCaptureRectClamped(newCaptureRect, Vector2.zero, Vector2.zero, true, true)
+		end
+	end, { setCaptureRectClamped, updateCaptureRef })
 
 	return captureRect, setCaptureRectClamped
 end

--- a/src/Main/UserInterface/Apps/Viewport/Components/FullViewport/ActionBar.luau
+++ b/src/Main/UserInterface/Apps/Viewport/Components/FullViewport/ActionBar.luau
@@ -3,28 +3,27 @@ local StudioComponents = require(pluginRoot.Packages.StudioComponents)
 local Lucide = require(pluginRoot.Packages.Lucide)
 local React = require(pluginRoot.Packages.React)
 
-local StateManager = require(pluginRoot.Main.StateManager)
-
 local uiRoot = script:FindFirstAncestor("UserInterface")
 local BaseButton = require(uiRoot.Components.BaseButton)
 local Hooks = require(uiRoot.Hooks)
 
+local MOVE_ICON = assert(Lucide.GetAsset("move", 16))
+local CAMERA_ICON = assert(Lucide.GetAsset("camera", 16))
+local MINIMIZE_ICON = assert(Lucide.GetAsset("minimize", 16))
+local CIRCLE_CHECK_ICON = assert(Lucide.GetAsset("circle-check", 16))
+
 export type Props = {
 	ViewportRect: Rect,
+	ScaleOS: Vector2,
+	IsRectRequest: boolean,
 	OnMinimize: () -> (),
 	OnCapture: (Rect) -> (boolean, string?),
 	Disabled: boolean?,
 }
 
 local function ActionBar(props: Props)
-	local moveIcon = assert(Lucide.GetAsset("move", 16))
-	local cameraIcon = assert(Lucide.GetAsset("camera", 16))
-	local minimizeIcon = assert(Lucide.GetAsset("minimize", 16))
-
 	local theme = StudioComponents.useTheme()
-	local scaleOS = StateManager.temporary:useSpecific()(function(state)
-		return state.scaleOS
-	end)
+	local captureIcon = if props.IsRectRequest then CIRCLE_CHECK_ICON else CAMERA_ICON
 
 	local underFrameRef = React.useRef(nil)
 	local underFrameAbsPosition = Hooks.useRefProperty(underFrameRef, "AbsolutePosition", Vector2.zero)
@@ -43,8 +42,8 @@ local function ActionBar(props: Props)
 
 	-- stylua: ignore
 	local displaySize = Vector2.new(
-		math.round(scaleOS.X * props.ViewportRect.Width),
-		math.round(scaleOS.Y * props.ViewportRect.Height)
+		math.round(props.ScaleOS.X * props.ViewportRect.Width),
+		math.round(props.ScaleOS.Y * props.ViewportRect.Height)
 	)
 
 	return React.createElement("Frame", {
@@ -83,11 +82,11 @@ local function ActionBar(props: Props)
 				}),
 
 				Icon = React.createElement("ImageLabel", {
-					Image = moveIcon.Url,
-					ImageRectSize = moveIcon.ImageRectSize,
-					ImageRectOffset = moveIcon.ImageRectOffset,
+					Image = MOVE_ICON.Url,
+					ImageRectSize = MOVE_ICON.ImageRectSize,
+					ImageRectOffset = MOVE_ICON.ImageRectOffset,
 
-					Size = UDim2.fromOffset(moveIcon.ImageRectSize.X, moveIcon.ImageRectSize.Y),
+					Size = UDim2.fromOffset(MOVE_ICON.ImageRectSize.X, MOVE_ICON.ImageRectSize.Y),
 					BackgroundTransparency = 1,
 					ImageColor3 = Color3.fromRGB(102, 102, 102),
 					LayoutOrder = 1,
@@ -127,11 +126,11 @@ local function ActionBar(props: Props)
 					TextColorStyle = Enum.StudioStyleGuideColor.ButtonText,
 
 					Icon = {
-						Image = minimizeIcon.Url,
-						RectSize = minimizeIcon.ImageRectSize,
-						RectOffset = minimizeIcon.ImageRectOffset,
+						Image = MINIMIZE_ICON.Url,
+						RectSize = MINIMIZE_ICON.ImageRectSize,
+						RectOffset = MINIMIZE_ICON.ImageRectOffset,
 
-						Size = minimizeIcon.ImageRectSize,
+						Size = MINIMIZE_ICON.ImageRectSize,
 						Transparency = if props.Disabled then 0.7 else 0,
 						UseThemeColor = true,
 					},
@@ -151,11 +150,11 @@ local function ActionBar(props: Props)
 					Size = UDim2.new(0, 24, 1, 0),
 
 					Icon = {
-						Image = cameraIcon.Url,
-						RectSize = cameraIcon.ImageRectSize,
-						RectOffset = cameraIcon.ImageRectOffset,
+						Image = captureIcon.Url,
+						RectSize = captureIcon.ImageRectSize,
+						RectOffset = captureIcon.ImageRectOffset,
 
-						Size = cameraIcon.ImageRectSize,
+						Size = captureIcon.ImageRectSize,
 						Transparency = if props.Disabled then 0.7 else 0,
 						Color = Color3.new(1, 1, 1),
 					},

--- a/src/Main/UserInterface/Apps/Viewport/Components/FullViewport/FullViewport.story.luau
+++ b/src/Main/UserInterface/Apps/Viewport/Components/FullViewport/FullViewport.story.luau
@@ -17,6 +17,9 @@ return CreateStory.theme(function(props)
 		BackgroundTransparency = 1,
 	}, {
 		FullViewport = React.createElement(FullViewport, {
+			ScaleOS = Vector2.new(1, 1),
+			IsRectRequest = false,
+
 			OnMinimize = function()
 				print("Minimize")
 			end,

--- a/src/Main/UserInterface/Apps/Viewport/Components/FullViewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/Components/FullViewport/init.luau
@@ -12,6 +12,8 @@ local DRAGGER_SIZE = Vector2.new(148, 28)
 local DRAGGER_SIZE_2 = DRAGGER_SIZE * 2
 
 export type Props = {
+	ScaleOS: Vector2,
+	IsRectRequest: boolean,
 	OnCapture: (Rect) -> (boolean, string?),
 	OnMinimize: () -> (),
 	Visible: boolean,
@@ -72,6 +74,8 @@ local function FullViewport(props: Props & { ViewportRect: Rect })
 			Disabled = props.Disabled,
 		}, {
 			ActionBar = React.createElement(ActionBar, {
+				ScaleOS = props.ScaleOS,
+				IsRectRequest = props.IsRectRequest,
 				ViewportRect = props.ViewportRect,
 				OnMinimize = props.OnMinimize,
 				OnCapture = props.OnCapture,
@@ -94,6 +98,8 @@ return function(props: Props)
 		ref = viewportRef,
 	}, {
 		Core = props.Visible and React.createElement(FullViewport, {
+			ScaleOS = props.ScaleOS,
+			IsRectRequest = props.IsRectRequest,
 			ViewportRect = viewportRect,
 			OnCapture = props.OnCapture,
 			OnMinimize = props.OnMinimize,

--- a/src/Main/UserInterface/Apps/Viewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/init.luau
@@ -5,9 +5,11 @@ local SelectionService = game:GetService("Selection")
 local pluginRoot = script:FindFirstAncestor("PluginRoot")
 local StudioComponents = require(pluginRoot.Packages.StudioComponents)
 local ReactRoblox = require(pluginRoot.Packages.ReactRoblox)
+local Future = require(pluginRoot.Packages.Future)
 local React = require(pluginRoot.Packages.React)
 local Trove = require(pluginRoot.Packages.Trove)
 
+local ObservableValue = require(pluginRoot.Main.StateManager.ObservableValue)
 local StateManager = require(pluginRoot.Main.StateManager)
 local UIHider = require(pluginRoot.Main.Photo.Tools.UIHider)
 local Captures = require(pluginRoot.Main.Photo.Captures)
@@ -18,11 +20,196 @@ local RenderRect = require(bindingRoot.Helpers.RenderRect)
 
 local uiRoot = script:FindFirstAncestor("UserInterface")
 local ToolbarButton = require(uiRoot.Helpers.ToolbarButton)
+local Hooks = require(uiRoot.Hooks)
 
 local CroppedViewport = require(script.Components.CroppedViewport)
 local FullViewport = require(script.Components.FullViewport)
 
 local ViewportApp = {}
+
+type RectRequest = {
+	scaleOS: Vector2?,
+	initialRect: Rect?,
+	resultFuture: Future.Future<Rect?>,
+}
+
+local rectRequestQueue = ObservableValue.new({} :: { RectRequest })
+
+local function clearAllRectRequests()
+	local queue = rectRequestQueue:get()
+	rectRequestQueue:set({})
+	for _, rectRequest in pairs(queue) do
+		rectRequest.resultFuture:complete(nil)
+	end
+	table.clear(queue)
+end
+
+local function useRectRequest()
+	local rectQueue = rectRequestQueue:use()
+	local rectRequest = rectQueue[1]
+
+	local remove = React.useCallback(function()
+		rectRequestQueue:update()(function(queue)
+			table.remove(queue, 1)
+			return queue
+		end)
+	end, { rectRequest })
+
+	return rectRequest, remove
+end
+
+local function createCenterRect(scale: Vector2)
+	local currentCamera = workspace.CurrentCamera :: Camera
+	return RenderRect.fromViewportCenter(currentCamera.ViewportSize * scale)
+end
+
+local function useCaptureRect()
+	-- we use a ref b/c in most cases we don't need to re-render the whole tree when we update this value
+	-- we have a custom update value which can be used to trigger re-renders, but it's used only when
+	-- there's a hard override we want to set (which doesn't occur often)
+	local captureRectRef = React.useRef(createCenterRect(Vector2.new(0.5, 0.5)))
+	local forceUpdate = Hooks.useUpdate()
+
+	local update = React.useCallback(function(newRect: Rect)
+		captureRectRef.current = newRect
+		forceUpdate()
+	end, { forceUpdate })
+
+	return captureRectRef, update
+end
+
+local function appComponent(props: { Button: PluginToolbarButton })
+	local isEnabled, setIsEnabled = React.useState(false)
+	local rectRequest, removeRectRequest = useRectRequest()
+	local captureRectRef, updateCaptureRectRef = useCaptureRect()
+	local screenGuiRef = React.useRef(nil :: ScreenGui?)
+
+	local isCapturing = StateManager.temporary:useSpecific()(function(state)
+		return state.isCapturing
+	end)
+
+	local isFullscreen = StateManager.temporary:useSpecific()(function(state)
+		return state.isFullscreen
+	end)
+
+	local scaleOS = StateManager.temporary:useSpecific()(function(state)
+		return state.scaleOS
+	end)
+
+	React.useEffect(function()
+		local trove = Trove.new()
+		trove:Add(props.Button.Click:Connect(function()
+			local newIsEnabled = not isEnabled
+			if newIsEnabled then
+				updateCaptureRectRef(createCenterRect(Vector2.new(0.5, 0.5)))
+			else
+				clearAllRectRequests()
+			end
+			setIsEnabled(newIsEnabled)
+		end))
+
+		return function()
+			trove:Destroy()
+		end
+	end, { isEnabled })
+
+	React.useEffect(function()
+		if rectRequest then
+			if rectRequest.initialRect then
+				updateCaptureRectRef(rectRequest.initialRect)
+			end
+
+			StateManager.temporary:update()(function(state)
+				state.isFullscreen = false
+				return state
+			end)
+
+			setIsEnabled(true)
+		end
+	end, { rectRequest })
+
+	local onCapture = React.useCallback(function(rect: Rect)
+		if rectRequest then
+			rectRequest.resultFuture:complete(rect)
+			removeRectRequest()
+			setIsEnabled(false)
+			return true, "" :: string?
+		end
+
+		local captureTypeIndex = StateManager.temporary:get().viewportCaptureTypeIndex
+		local captureType = assert(Captures.Viewport.Order[captureTypeIndex], "No capture type found")
+
+		local trove = Trove.new()
+		if screenGuiRef.current and UIHider.isViewportAppExcluded(rect) then
+			trove:Add(UIHider.addExclusion(screenGuiRef.current))
+		end
+
+		local captures, err = Photo.captureViewport({
+			rect = rect,
+			type = captureType :: Captures.ViewportCaptureTypes,
+		})
+
+		trove:Destroy()
+
+		local selection = Photo.export(captures, StarterGui)
+		SelectionService:Set(selection :: any)
+		return not err, err
+	end, { rectRequest })
+
+	local onMinMax = React.useCallback(function()
+		StateManager.temporary:update()(function(state)
+			state.isFullscreen = not state.isFullscreen
+			return state
+		end)
+	end, {})
+
+	props.Button:SetActive(isEnabled)
+
+	return isEnabled
+		and React.createElement("ScreenGui", {
+			Name = "ViewportApp",
+			DisplayOrder = math.huge, -- this is so enabled ScreenGuis in say StarterGui don't stop Photobooth from receiving input
+			Archivable = false,
+			IgnoreGuiInset = true,
+			ZIndexBehavior = Enum.ZIndexBehavior.Sibling,
+			ref = screenGuiRef,
+		}, {
+			Fullscreen = React.createElement(FullViewport, {
+				IsRectRequest = not not rectRequest,
+				ScaleOS = scaleOS,
+				OnMinimize = onMinMax,
+				OnCapture = onCapture,
+				Visible = isFullscreen :: boolean,
+				Disabled = isCapturing,
+			}),
+
+			Cropped = React.createElement(CroppedViewport, {
+				IsRectRequest = not not rectRequest,
+				ScaleOS = rectRequest and rectRequest.scaleOS or scaleOS,
+				CaptureRectRef = captureRectRef,
+				UpdateCaptureRectRef = updateCaptureRectRef,
+				OnMaximize = onMinMax,
+				OnCapture = onCapture,
+				Visible = not isFullscreen :: boolean,
+				Disabled = isCapturing,
+			}),
+		})
+end
+
+function ViewportApp.requestRect(rect: Rect?, scaleOS: Vector2?)
+	local resultFuture = Future.new()
+	rectRequestQueue:update()(function(queue)
+		table.insert(queue, {
+			scaleOS = scaleOS,
+			initialRect = rect,
+			resultFuture = resultFuture,
+		})
+		return queue
+	end)
+
+	local resultRect = resultFuture:expect()
+	return resultRect
+end
 
 function ViewportApp.mount(plugin: Plugin, toolbar: PluginToolbar)
 	-- stylua: ignore
@@ -39,109 +226,28 @@ function ViewportApp.mount(plugin: Plugin, toolbar: PluginToolbar)
 	folder.Archivable = false
 	folder.Parent = CoreGui
 
-	local function ViewportApp(): React.ReactNode?
-		local isEnabled, setIsEnabled = React.useState(false)
-
-		local isCapturing = StateManager.temporary:useSpecific()(function(state)
-			return state.isCapturing
-		end)
-
-		local isFullscreen = StateManager.temporary:useSpecific()(function(state)
-			return state.isFullscreen
-		end)
-
-		local captureRectRef = React.useRef(RenderRect.fromViewportCenter(workspace.CurrentCamera.ViewportSize / 2))
-		local prevCaptureRectRef = React.useRef(captureRectRef.current)
-
-		local screenGuiRef = React.useRef(nil :: ScreenGui?)
-
-		local updatePrevCaptureRectRef = React.useCallback(function()
-			local captureRect = captureRectRef.current
-			if not StateManager.temporary:get().isFullscreen and captureRect then
-				prevCaptureRectRef.current = captureRect
-			end
-		end, {})
-
-		React.useEffect(function()
-			local trove = Trove.new()
-			trove:Add(openButton.Click:Connect(function()
-				updatePrevCaptureRectRef()
-				setIsEnabled(not isEnabled)
-			end))
-
-			return function()
-				trove:Destroy()
-			end
-		end, { isEnabled })
-
-		local onCapture = React.useCallback(function(rect: Rect)
-			local captureTypeIndex = StateManager.temporary:get().viewportCaptureTypeIndex
-			local captureType = assert(Captures.Viewport.Order[captureTypeIndex], "No capture type found")
-
-			local trove = Trove.new()
-			if screenGuiRef.current and UIHider.isViewportAppExcluded(rect) then
-				trove:Add(UIHider.addExclusion(screenGuiRef.current))
-			end
-
-			local captures, err = Photo.captureViewport({
-				rect = rect,
-				type = captureType :: Captures.ViewportCaptureTypes,
-			})
-
-			trove:Destroy()
-
-			local selection = Photo.export(captures, StarterGui)
-			SelectionService:Set(selection :: any)
-			return not err, err
-		end, {})
-
-		local onMinMax = React.useCallback(function()
-			local prevRect = prevCaptureRectRef.current
-			updatePrevCaptureRectRef()
-			captureRectRef.current = prevRect
-			StateManager.temporary:update()(function(state)
-				state.isFullscreen = not state.isFullscreen
-				return state
-			end)
-		end, {})
-
-		openButton:SetActive(isEnabled)
-
-		-- stylua: ignore
-		return isEnabled and React.createElement("ScreenGui", {
-			Name = "ViewportApp",
-			DisplayOrder = math.huge, -- this is so enabled ScreenGuis in say StarterGui don't stop Photobooth from receiving input
-			Archivable = false,
-			IgnoreGuiInset = true,
-			ZIndexBehavior = Enum.ZIndexBehavior.Sibling,
-			ref = screenGuiRef,
-		}, {
-			Fullscreen = React.createElement(FullViewport, {
-				OnMinimize = onMinMax,
-				OnCapture = onCapture,
-				Visible = isFullscreen :: boolean,
-				Disabled = isCapturing,
-			}),
-
-			Cropped = React.createElement(CroppedViewport, {
-				OnMaximize = onMinMax,
-				OnCapture = onCapture,
-				Visible = not isFullscreen :: boolean,
-				Disabled = isCapturing,
-			}),
-		})
-	end
-
 	local coreGuiRoot = ReactRoblox.createRoot(folder)
 	coreGuiRoot:render(React.createElement(StudioComponents.PluginProvider, {
 		Plugin = plugin,
 	}, {
-		App = React.createElement(ViewportApp),
+		App = React.createElement(appComponent, {
+			Button = openButton,
+		}),
 	}))
 
 	plugin.Unloading:Connect(function()
+		clearAllRectRequests()
 		coreGuiRoot:unmount()
 		folder:Destroy()
+	end)
+
+	task.delay(5, function()
+		print("Request")
+		local rect = RenderRect.fromViewportCenter(Vector2.new(512, 512))
+		-- local result1 = ViewportApp.requestRect(rect, Vector2.new(1.5, 1.5))
+		-- local result2 = ViewportApp.requestRect(rect, Vector2.new(1, 1))
+		local result3 = ViewportApp.requestRect(rect, Vector2.new(0.5, 0.5))
+		print(result3)
 	end)
 end
 

--- a/src/Main/UserInterface/Apps/Viewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/init.luau
@@ -35,13 +35,18 @@ type RectRequest = {
 
 local rectRequestQueue = ObservableValue.new({} :: { RectRequest })
 
+local function safeComplete<T...>(f: Future.Future<T...>, ...: T...)
+	if not f:isCompleted() then
+		f:complete(...)
+	end
+end
+
 local function clearAllRectRequests()
 	local queue = rectRequestQueue:get()
 	rectRequestQueue:set({})
 	for _, rectRequest in pairs(queue) do
-		rectRequest.resultFuture:complete(nil)
+		safeComplete(rectRequest.resultFuture, nil)
 	end
-	table.clear(queue)
 end
 
 local function useRectRequest()
@@ -60,8 +65,10 @@ end
 
 local function createCenterRect(scale: Vector2)
 	local scaleOS = StateManager.temporary:get().scaleOS
-	local currentCamera = workspace.CurrentCamera :: Camera
-	return RenderRect.fromViewportCenter((currentCamera.ViewportSize * scale) / scaleOS)
+	local viewportSize = (workspace.CurrentCamera :: Camera).ViewportSize * scaleOS
+	local rectSize = viewportSize * scale
+	local absPosition = (viewportSize - rectSize) / 2
+	return RenderRect.fromAbs(absPosition, rectSize)
 end
 
 local function useCaptureRect()
@@ -131,7 +138,7 @@ local function appComponent(props: { Button: PluginToolbarButton })
 
 	local onCapture = React.useCallback(function(rect: Rect)
 		if rectRequest then
-			rectRequest.resultFuture:complete(rect)
+			safeComplete(rectRequest.resultFuture, rect)
 			removeRectRequest()
 			setIsEnabled(false)
 			return true, "" :: string?

--- a/src/Main/UserInterface/Apps/Viewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/init.luau
@@ -28,12 +28,19 @@ local FullViewport = require(script.Components.FullViewport)
 local ViewportApp = {}
 
 type RectRequest = {
+	guid: string,
 	scaleOS: Vector2,
 	initialRect: Rect,
 	resultFuture: Future.Future<Rect?>,
 }
 
+type RectRequestControl = {
+	expect: () -> Rect?,
+	cancel: () -> (),
+}
+
 local rectRequestQueue = ObservableValue.new({} :: { RectRequest })
+local rectRequestControlByGuid: { [string]: RectRequestControl } = {}
 
 local function safeComplete<T...>(f: Future.Future<T...>, ...: T...)
 	if not f:isCompleted() then
@@ -47,7 +54,10 @@ local function useRectRequest()
 
 	local remove = React.useCallback(function()
 		rectRequestQueue:update()(function(queue)
-			table.remove(queue, 1)
+			local popped = table.remove(queue, 1)
+			if popped then
+				rectRequestControlByGuid[popped.guid] = nil
+			end
 			return queue
 		end)
 	end, { rectRequest })
@@ -114,6 +124,7 @@ local function appComponent(props: { Button: PluginToolbarButton })
 	end, { isEnabled })
 
 	React.useEffect(function()
+		local connection
 		if rectRequest then
 			updateCaptureRectRef(rectRequest.initialRect)
 
@@ -123,6 +134,17 @@ local function appComponent(props: { Button: PluginToolbarButton })
 			end)
 
 			setIsEnabled(true)
+			connection = rectRequestQueue:onChanged(function()
+				if #rectRequestQueue:get() == 0 then
+					setIsEnabled(false)
+				end
+			end)
+		end
+
+		return function()
+			if connection then
+				connection:Disconnect()
+			end
 		end
 	end, { rectRequest })
 
@@ -130,7 +152,6 @@ local function appComponent(props: { Button: PluginToolbarButton })
 		if rectRequest then
 			safeComplete(rectRequest.resultFuture, rect)
 			removeRectRequest()
-			setIsEnabled(false)
 			return true, "" :: string?
 		end
 
@@ -194,11 +215,12 @@ local function appComponent(props: { Button: PluginToolbarButton })
 		})
 end
 
-function ViewportApp.requestRect(rect: Rect?, scaleOS: Vector2?)
+function ViewportApp.requestRect(guid: string, rect: Rect?, scaleOS: Vector2?)
 	local resultFuture = Future.new()
 	local renderScaleOS = scaleOS or Vector2.one
 
 	local entry = {
+		guid = guid,
 		scaleOS = renderScaleOS,
 		initialRect = rect or createCenterRect(Vector2.new(0.5, 0.5), renderScaleOS),
 		resultFuture = resultFuture,
@@ -219,6 +241,7 @@ function ViewportApp.requestRect(rect: Rect?, scaleOS: Vector2?)
 				local foundIndex = table.find(queue, entry)
 				if foundIndex then
 					table.remove(queue, foundIndex)
+					rectRequestControlByGuid[entry.guid] = nil
 				end
 				return queue
 			end)
@@ -226,15 +249,24 @@ function ViewportApp.requestRect(rect: Rect?, scaleOS: Vector2?)
 		end
 	end
 
-	return {
+	local requestControl: RectRequestControl = {
 		expect = expect,
 		cancel = cancel,
 	}
+
+	rectRequestControlByGuid[entry.guid] = requestControl
+
+	return requestControl
+end
+
+function ViewportApp.getRectRequestByGuid(guid: string)
+	return rectRequestControlByGuid[guid] :: RectRequestControl?
 end
 
 function ViewportApp.clearAllRectRequests()
 	local queue = rectRequestQueue:get()
 	rectRequestQueue:set({})
+	table.clear(rectRequestControlByGuid)
 	for _, rectRequest in pairs(queue) do
 		safeComplete(rectRequest.resultFuture, nil)
 	end

--- a/src/Main/UserInterface/Apps/Viewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/init.luau
@@ -41,14 +41,6 @@ local function safeComplete<T...>(f: Future.Future<T...>, ...: T...)
 	end
 end
 
-local function clearAllRectRequests()
-	local queue = rectRequestQueue:get()
-	rectRequestQueue:set({})
-	for _, rectRequest in pairs(queue) do
-		safeComplete(rectRequest.resultFuture, nil)
-	end
-end
-
 local function useRectRequest()
 	local rectQueue = rectRequestQueue:use()
 	local rectRequest = rectQueue[1]
@@ -111,7 +103,7 @@ local function appComponent(props: { Button: PluginToolbarButton })
 			if newIsEnabled then
 				updateCaptureRectRef(createCenterRect(Vector2.new(0.5, 0.5)))
 			else
-				clearAllRectRequests()
+				ViewportApp.clearAllRectRequests()
 			end
 			setIsEnabled(newIsEnabled)
 		end))
@@ -205,17 +197,47 @@ end
 function ViewportApp.requestRect(rect: Rect?, scaleOS: Vector2?)
 	local resultFuture = Future.new()
 	local renderScaleOS = scaleOS or Vector2.one
+
+	local entry = {
+		scaleOS = renderScaleOS,
+		initialRect = rect or createCenterRect(Vector2.new(0.5, 0.5), renderScaleOS),
+		resultFuture = resultFuture,
+	}
+
 	rectRequestQueue:update()(function(queue)
-		table.insert(queue, {
-			scaleOS = renderScaleOS,
-			initialRect = rect or createCenterRect(Vector2.new(0.5, 0.5), renderScaleOS),
-			resultFuture = resultFuture,
-		})
+		table.insert(queue, entry)
 		return queue
 	end)
 
-	local resultRect = resultFuture:expect()
-	return resultRect
+	local function expect()
+		return resultFuture:expect()
+	end
+
+	local function cancel()
+		if not resultFuture:isCompleted() then
+			rectRequestQueue:update()(function(queue)
+				local foundIndex = table.find(queue, entry)
+				if foundIndex then
+					table.remove(queue, foundIndex)
+				end
+				return queue
+			end)
+			resultFuture:complete(nil)
+		end
+	end
+
+	return {
+		expect = expect,
+		cancel = cancel,
+	}
+end
+
+function ViewportApp.clearAllRectRequests()
+	local queue = rectRequestQueue:get()
+	rectRequestQueue:set({})
+	for _, rectRequest in pairs(queue) do
+		safeComplete(rectRequest.resultFuture, nil)
+	end
 end
 
 function ViewportApp.mount(plugin: Plugin, toolbar: PluginToolbar)
@@ -243,7 +265,7 @@ function ViewportApp.mount(plugin: Plugin, toolbar: PluginToolbar)
 	}))
 
 	plugin.Unloading:Connect(function()
-		clearAllRectRequests()
+		ViewportApp.clearAllRectRequests()
 		coreGuiRoot:unmount()
 		folder:Destroy()
 	end)

--- a/src/Main/UserInterface/Apps/Viewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/init.luau
@@ -54,10 +54,7 @@ local function useRectRequest()
 
 	local remove = React.useCallback(function()
 		rectRequestQueue:update()(function(queue)
-			local popped = table.remove(queue, 1)
-			if popped then
-				rectRequestControlByGuid[popped.guid] = nil
-			end
+			table.remove(queue, 1)
 			return queue
 		end)
 	end, { rectRequest })
@@ -232,7 +229,9 @@ function ViewportApp.requestRect(guid: string, rect: Rect?, scaleOS: Vector2?)
 	end)
 
 	local function expect()
-		return resultFuture:expect()
+		local result = resultFuture:expect()
+		rectRequestControlByGuid[entry.guid] = nil
+		return result
 	end
 
 	local function cancel()

--- a/src/Main/UserInterface/Apps/Viewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/init.luau
@@ -59,8 +59,9 @@ local function useRectRequest()
 end
 
 local function createCenterRect(scale: Vector2)
+	local scaleOS = StateManager.temporary:get().scaleOS
 	local currentCamera = workspace.CurrentCamera :: Camera
-	return RenderRect.fromViewportCenter(currentCamera.ViewportSize * scale)
+	return RenderRect.fromViewportCenter((currentCamera.ViewportSize * scale) / scaleOS)
 end
 
 local function useCaptureRect()
@@ -185,7 +186,10 @@ local function appComponent(props: { Button: PluginToolbarButton })
 
 			Cropped = React.createElement(CroppedViewport, {
 				IsRectRequest = not not rectRequest,
-				ScaleOS = rectRequest and rectRequest.scaleOS or scaleOS,
+				ScaleOS = if rectRequest and rectRequest.scaleOS
+					then scaleOS / rectRequest.scaleOS
+					elseif rectRequest then Vector2.one
+					else scaleOS,
 				CaptureRectRef = captureRectRef,
 				UpdateCaptureRectRef = updateCaptureRectRef,
 				OnMaximize = onMinMax,
@@ -246,7 +250,7 @@ function ViewportApp.mount(plugin: Plugin, toolbar: PluginToolbar)
 		local rect = RenderRect.fromViewportCenter(Vector2.new(512, 512))
 		-- local result1 = ViewportApp.requestRect(rect, Vector2.new(1.5, 1.5))
 		-- local result2 = ViewportApp.requestRect(rect, Vector2.new(1, 1))
-		local result3 = ViewportApp.requestRect(rect, Vector2.new(0.5, 0.5))
+		local result3 = ViewportApp.requestRect(rect, Vector2.new(1.25, 1.25))
 		print(result3)
 	end)
 end

--- a/src/Main/UserInterface/Apps/Viewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/init.luau
@@ -265,7 +265,6 @@ function ViewportApp.mount(plugin: Plugin, toolbar: PluginToolbar)
 	}))
 
 	plugin.Unloading:Connect(function()
-		ViewportApp.clearAllRectRequests()
 		coreGuiRoot:unmount()
 		folder:Destroy()
 	end)

--- a/src/Main/UserInterface/Apps/Viewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/init.luau
@@ -248,18 +248,6 @@ function ViewportApp.mount(plugin: Plugin, toolbar: PluginToolbar)
 		coreGuiRoot:unmount()
 		folder:Destroy()
 	end)
-
-	task.delay(5, function()
-		local scaleOS = Vector2.new(1, 1)
-		local size = Vector2.new(512, 512)
-
-		local viewportSize = (workspace.CurrentCamera :: Camera).ViewportSize * scaleOS
-		local absPosition = (viewportSize - size) / 2
-		local rect = RenderRect.fromAbs(absPosition, size)
-
-		local result = ViewportApp.requestRect(rect, scaleOS)
-		print(result)
-	end)
 end
 
 return ViewportApp

--- a/src/Main/UserInterface/Apps/Viewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/init.luau
@@ -28,7 +28,7 @@ local FullViewport = require(script.Components.FullViewport)
 local ViewportApp = {}
 
 type RectRequest = {
-	scaleOS: Vector2?,
+	scaleOS: Vector2,
 	initialRect: Rect?,
 	resultFuture: Future.Future<Rect?>,
 }
@@ -186,10 +186,7 @@ local function appComponent(props: { Button: PluginToolbarButton })
 
 			Cropped = React.createElement(CroppedViewport, {
 				IsRectRequest = not not rectRequest,
-				ScaleOS = if rectRequest and rectRequest.scaleOS
-					then scaleOS / rectRequest.scaleOS
-					elseif rectRequest then Vector2.one
-					else scaleOS,
+				ScaleOS = if rectRequest then rectRequest.scaleOS else scaleOS,
 				CaptureRectRef = captureRectRef,
 				UpdateCaptureRectRef = updateCaptureRectRef,
 				OnMaximize = onMinMax,
@@ -204,7 +201,7 @@ function ViewportApp.requestRect(rect: Rect?, scaleOS: Vector2?)
 	local resultFuture = Future.new()
 	rectRequestQueue:update()(function(queue)
 		table.insert(queue, {
-			scaleOS = scaleOS,
+			scaleOS = scaleOS or Vector2.one,
 			initialRect = rect,
 			resultFuture = resultFuture,
 		})
@@ -246,12 +243,15 @@ function ViewportApp.mount(plugin: Plugin, toolbar: PluginToolbar)
 	end)
 
 	task.delay(5, function()
-		print("Request")
-		local rect = RenderRect.fromViewportCenter(Vector2.new(512, 512))
-		-- local result1 = ViewportApp.requestRect(rect, Vector2.new(1.5, 1.5))
-		-- local result2 = ViewportApp.requestRect(rect, Vector2.new(1, 1))
-		local result3 = ViewportApp.requestRect(rect, Vector2.new(1.25, 1.25))
-		print(result3)
+		local scaleOS = Vector2.new(1, 1)
+		local size = Vector2.new(512, 512)
+
+		local viewportSize = (workspace.CurrentCamera :: Camera).ViewportSize * scaleOS
+		local absPosition = (viewportSize - size) / 2
+		local rect = RenderRect.fromAbs(absPosition, size)
+
+		local result = ViewportApp.requestRect(rect, scaleOS)
+		print(result)
 	end)
 end
 

--- a/src/Main/UserInterface/Apps/Viewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/init.luau
@@ -29,7 +29,7 @@ local ViewportApp = {}
 
 type RectRequest = {
 	scaleOS: Vector2,
-	initialRect: Rect?,
+	initialRect: Rect,
 	resultFuture: Future.Future<Rect?>,
 }
 
@@ -63,9 +63,9 @@ local function useRectRequest()
 	return rectRequest, remove
 end
 
-local function createCenterRect(scale: Vector2)
-	local scaleOS = StateManager.temporary:get().scaleOS
-	local viewportSize = (workspace.CurrentCamera :: Camera).ViewportSize * scaleOS
+local function createCenterRect(scale: Vector2, scaleOS: Vector2?)
+	local renderScaleOS = scaleOS or StateManager.temporary:get().scaleOS
+	local viewportSize = (workspace.CurrentCamera :: Camera).ViewportSize * renderScaleOS
 	local rectSize = viewportSize * scale
 	local absPosition = (viewportSize - rectSize) / 2
 	return RenderRect.fromAbs(absPosition, rectSize)
@@ -123,9 +123,7 @@ local function appComponent(props: { Button: PluginToolbarButton })
 
 	React.useEffect(function()
 		if rectRequest then
-			if rectRequest.initialRect then
-				updateCaptureRectRef(rectRequest.initialRect)
-			end
+			updateCaptureRectRef(rectRequest.initialRect)
 
 			StateManager.temporary:update()(function(state)
 				state.isFullscreen = false
@@ -206,10 +204,11 @@ end
 
 function ViewportApp.requestRect(rect: Rect?, scaleOS: Vector2?)
 	local resultFuture = Future.new()
+	local renderScaleOS = scaleOS or Vector2.one
 	rectRequestQueue:update()(function(queue)
 		table.insert(queue, {
-			scaleOS = scaleOS or Vector2.one,
-			initialRect = rect,
+			scaleOS = renderScaleOS,
+			initialRect = rect or createCenterRect(Vector2.new(0.5, 0.5), renderScaleOS),
 			resultFuture = resultFuture,
 		})
 		return queue

--- a/src/Main/UserInterface/Hooks/Generic/useUpdate.luau
+++ b/src/Main/UserInterface/Hooks/Generic/useUpdate.luau
@@ -1,0 +1,11 @@
+local pluginRoot = script:FindFirstAncestor("PluginRoot")
+local React = require(pluginRoot.Packages.React)
+
+local function useUpdate()
+	local state, setState = React.useState({})
+	return React.useCallback(function()
+		setState({})
+	end, { state })
+end
+
+return useUpdate

--- a/src/Main/UserInterface/Hooks/init.luau
+++ b/src/Main/UserInterface/Hooks/init.luau
@@ -1,4 +1,5 @@
 -- Generic
+local useUpdate = require(script.Generic.useUpdate)
 local useConstant = require(script.Generic.useConstant)
 local useMouseDrag = require(script.Generic.useMouseDrag)
 local useSelection = require(script.Generic.useSelection)
@@ -24,6 +25,7 @@ export type EditableImageInfo = useEditableImageInfos.EditableImageInfo
 -- Exported
 
 return {
+	useUpdate = useUpdate,
 	useConstant = useConstant,
 	useMouseDrag = useMouseDrag,
 	useSelection = useSelection,

--- a/src/Main/UserInterface/init.luau
+++ b/src/Main/UserInterface/init.luau
@@ -10,8 +10,7 @@ function UserInterface.mountApps(plugin: Plugin, toolbar: PluginToolbar)
 	GalleryApp.mount(plugin, toolbar)
 end
 
-function UserInterface.rectRequest(rect: Rect?, scaleOS: Vector2?)
-	return ViewportApp.requestRect(rect, scaleOS)
-end
+UserInterface.rectRequest = ViewportApp.requestRect
+UserInterface.getRectRequestByGuid = ViewportApp.getRectRequestByGuid
 
 return UserInterface

--- a/src/Main/UserInterface/init.luau
+++ b/src/Main/UserInterface/init.luau
@@ -10,7 +10,7 @@ function UserInterface.mountApps(plugin: Plugin, toolbar: PluginToolbar)
 	GalleryApp.mount(plugin, toolbar)
 end
 
-UserInterface.rectRequest = ViewportApp.requestRect
+UserInterface.requestRect = ViewportApp.requestRect
 UserInterface.getRectRequestByGuid = ViewportApp.getRectRequestByGuid
 
 return UserInterface

--- a/src/Main/UserInterface/init.luau
+++ b/src/Main/UserInterface/init.luau
@@ -10,4 +10,8 @@ function UserInterface.mountApps(plugin: Plugin, toolbar: PluginToolbar)
 	GalleryApp.mount(plugin, toolbar)
 end
 
+function UserInterface.rectRequest(rect: Rect?, scaleOS: Vector2?)
+	return ViewportApp.requestRect(rect, scaleOS)
+end
+
 return UserInterface


### PR DESCRIPTION
This PR adds a new binding function that allows devs to request a rect on screen. It uses the same viewport app that's used for workspace capture.