### PR TITLE
Add OpenGL warn

### DIFF
--- a/src/Main/Photo/Captures/init.luau
+++ b/src/Main/Photo/Captures/init.luau
@@ -4,6 +4,9 @@ local Sift = require(pluginRoot.Packages.Sift)
 local StateManager = require(pluginRoot.Main.StateManager)
 local Types = require(pluginRoot.Main.Bindings.Interface.Types)
 
+local OPEN_GL_WARN =
+	"WARN: 'Studio Settings > Rendering > Graphics Mode = OpenGL' is unsupported by Photobooth due to a Roblox bug."
+
 -- Private
 
 local ticket = 0
@@ -14,6 +17,10 @@ local function wrap<T...>(callback: (T...) -> ...EditableImage)
 	local myTicket = ticket
 
 	local function wrapped(...: T...)
+		if settings().Rendering.GraphicsMode == Enum.GraphicsMode.OpenGL then
+			error(OPEN_GL_WARN, 0)
+		end
+
 		return { callback(...) }
 	end
 


### PR DESCRIPTION
OpenGL graphics mode is not supported by photobooth because of a Roblox bug that causes capture service results to become complete messes.

https://devforum.roblox.com/t/captureservice-results-are-terrible-with-opengl-rendering-mode/4059797

In this PR I check your graphics mode before a capture and fail / send a warn to the output explaining that this graphics mode is unsupported.