### PR TITLE
Use old UIBounds

### DIFF
--- a/src/Main/Photo/Captures/CaptureTypes/UserInterface/AlphaMask.luau
+++ b/src/Main/Photo/Captures/CaptureTypes/UserInterface/AlphaMask.luau
@@ -5,7 +5,7 @@ local Trove = require(pluginRoot.Packages.Trove)
 local photoRoot = script:FindFirstAncestor("Photo")
 local Screenshot = require(photoRoot.Captures.Screenshot)
 local SceneControl = require(photoRoot.SceneControl)
-local UIBounds = require(photoRoot.Tools.UIBoundsScreen)
+local UIBounds = require(photoRoot.Tools.UIBounds)
 local UIHider = require(photoRoot.Tools.UIHider)
 
 local capturesRoot = script:FindFirstAncestor("Captures")
@@ -49,7 +49,7 @@ local function operation(options: Types.CaptureUIOptions, trove: Trove.Trove)
 	trove:Add(colorCorrection)
 
 	local errorWatch, markComplete = SceneControl.cleanupOnError(trove)
-	local capture = errorWatch(Composers.reverseBlend(onWhite, onBlack, nil, colorCorrection))
+	local capture = errorWatch(Composers.reverseBlend(onWhite, onBlack, nil, nil, colorCorrection))
 	if options.alphaBleed then
 		capture = errorWatch(Composers.alphaBleed(capture))
 	end

--- a/src/Main/Photo/Captures/CaptureTypes/UserInterface/NoBackground.luau
+++ b/src/Main/Photo/Captures/CaptureTypes/UserInterface/NoBackground.luau
@@ -5,7 +5,7 @@ local Trove = require(pluginRoot.Packages.Trove)
 local photoRoot = script:FindFirstAncestor("Photo")
 local Screenshot = require(photoRoot.Captures.Screenshot)
 local SceneControl = require(photoRoot.SceneControl)
-local UIBounds = require(photoRoot.Tools.UIBoundsScreen)
+local UIBounds = require(photoRoot.Tools.UIBounds)
 local UIHider = require(photoRoot.Tools.UIHider)
 
 local capturesRoot = script:FindFirstAncestor("Captures")
@@ -48,7 +48,7 @@ local function operation(options: Types.CaptureUIOptions, trove: Trove.Trove)
 	trove:Add(colorCorrection)
 
 	local errorWatch, markComplete = SceneControl.cleanupOnError(trove)
-	local capture = errorWatch(Composers.reverseBlend(onWhite, onBlack, nil, colorCorrection))
+	local capture = errorWatch(Composers.reverseBlend(onWhite, onBlack, nil, nil, colorCorrection))
 	if options.alphaBleed then
 		capture = errorWatch(Composers.alphaBleed(capture))
 	end


### PR DESCRIPTION
Roblox introduced a new FFlag that wouldn't allow you to capture UI with an always on top surface gui via the capture service. You can read about it here:
https://devforum.roblox.com/t/4726398

I temporarily switched to placing a screen gui in the starter gui. This wasn't optimal for two reasons:
1. It didn't always work - it was buggy
2. It could only support OS scaling on one axis - fine if your OS scale was symetrical (which it should be), but not a flex as the old method

Roblox disabled that flag so we can capture UI again so I'm reverting back to the old better method.