### PR TITLE
Add auto-capture script injections check

### DIFF
--- a/src/Main/UserInterface/Apps/AutoCapture/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/init.luau
@@ -25,11 +25,21 @@ local AutoCapture = {}
 local function hideWorkspace(callback: () -> ())
 	local terrain = workspace.Terrain
 	local camera = workspace.CurrentCamera
-	local children = workspace:GetChildren()
+
+	local foundLuaSourceContainer = workspace:FindFirstChildWhichIsA("LuaSourceContainer", true)
+	if foundLuaSourceContainer then
+		-- This may seem like a really funny thing to do. Why create a module and immediately destroy it?
+		-- This will trigger the script injection permissions check which is needed to re-parent the user's scripts back
+		-- into the workspace. If we don't have this then we may error post-callback and the workspace will be unintentionally cleared
+		local probe = Instance.new("ModuleScript")
+		probe.Parent = workspace
+		probe:Destroy()
+	end
 
 	local recording = ChangeHistoryService:TryBeginRecording("AutoCapture", "Auto Capture")
 
 	local hidden = {}
+	local children = workspace:GetChildren()
 	for _, child in children do
 		if child ~= camera and child ~= terrain then
 			table.insert(hidden, {


### PR DESCRIPTION
# Problem

User reported that workspace could be cleared when using the auto capture if the workspace had scripts in it.
https://devforum.roblox.com/t/photobooth-plugin/3401720/365?u=egomoose

# Solution

This was happening b/c the act of reparenting scripts triggers the script injection check. If the check isn't enabled then on reparent an error occurs and the whole workspace may be cleared. This happens before the change history record can be commited which means you can't even ctrl + z.

This is fixed by first doing a search for any scripts in the workspace and if there are then we do a empty module script insertion probe. This triggers the script injection check which will off an error before we've even started the auto-capture process so the workspace hasn't been cleared yet and nothing reparented.