### PR TITLE
Fix color correction and cloud hiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Unreleased
 - Unify right click menu across both the post processing and gallery apps
+- Fix color correction application on atmosphere present captures
+- Fix cloud hiding on atmosphere present captures
 
 ### [2.6.3] - 2026/07/18
 - Fix script injection check on auto-captures when the workspace has scripts in it

--- a/src/Main/Photo/Captures/CaptureTypes/Viewport/NoSkybox.luau
+++ b/src/Main/Photo/Captures/CaptureTypes/Viewport/NoSkybox.luau
@@ -18,6 +18,7 @@ local function operation(options: Types.CaptureViewportOptions, isFullscreen: bo
 
 	trove:Add(SceneControl.hideScreenUI())
 	local colorCorrection = trove:Add(SceneControl.getAppliedColorCorrectionCopy())
+	local undoColorCorrection = trove:Add(SceneControl.hideColorCorrections())
 
 	local fogBackground = Background.new(workspace)
 	fogBackground:setColor(Color3.new(0, 0, 0))
@@ -107,6 +108,7 @@ local function operation(options: Types.CaptureViewportOptions, isFullscreen: bo
 	end)
 
 	undoEmulator()
+	undoColorCorrection()
 
 	if setAtmosphereHidden then
 		setAtmosphereHidden(false)

--- a/src/Main/Photo/Captures/CaptureTypes/Viewport/NoSkybox.luau
+++ b/src/Main/Photo/Captures/CaptureTypes/Viewport/NoSkybox.luau
@@ -24,6 +24,8 @@ local function operation(options: Types.CaptureViewportOptions, isFullscreen: bo
 	fogBackground:setColor(Color3.new(0, 0, 0))
 	fogBackground:setEnabled(true)
 
+	local unhideClouds = trove:Add(SceneControl.hideClouds())
+
 	trove:Add(SceneControl.once(function()
 		fogBackground:Destroy()
 	end))
@@ -68,15 +70,11 @@ local function operation(options: Types.CaptureViewportOptions, isFullscreen: bo
 		camera.CFrame = renderCF
 		fogBackground:setMaterial(Enum.Material.SmoothPlastic)
 	elseif SceneControl.isGradedLightingRequired() or Lighting.ExposureCompensation ~= 0 then
-		local undoGradedLighting = trove:Add(SceneControl.applyGradedLighting())
-
 		SceneControl.yieldUntilNextFrame()
 		gradedOnBlack = Screenshot.rect(options.rect, isFullscreen, isEmulator)
 		trove:Add(function()
 			gradedOnBlack:Destroy()
 		end)
-
-		undoGradedLighting()
 	end
 
 	-- prepare for retro scene capturing
@@ -108,6 +106,7 @@ local function operation(options: Types.CaptureViewportOptions, isFullscreen: bo
 	end)
 
 	undoEmulator()
+	unhideClouds()
 	undoColorCorrection()
 
 	if setAtmosphereHidden then

--- a/src/Main/Photo/SceneControl.luau
+++ b/src/Main/Photo/SceneControl.luau
@@ -242,7 +242,7 @@ function SceneControl.isGradedLightingRequired()
 	return true
 end
 
-function SceneControl.applyGradedLighting()
+function SceneControl.hideClouds()
 	local clouds = {}
 	for _, child in workspace.Terrain:GetChildren() do
 		if child:IsA("Clouds") then
@@ -259,7 +259,7 @@ function SceneControl.applyGradedLighting()
 end
 
 function SceneControl.applyRetroLighting()
-	local undoGradedLighting = SceneControl.applyGradedLighting()
+	local unhideClouds = SceneControl.hideClouds()
 	local setAtmosphereHidden = SceneControl.getAtmosphereHider()
 
 	setAtmosphereHidden(true)
@@ -267,29 +267,16 @@ function SceneControl.applyRetroLighting()
 	local exposureCompensation = Lighting.ExposureCompensation
 	Lighting.ExposureCompensation = 0
 
-	local effects = {}
-	for _, child in Lighting:GetChildren() do
-		if child:IsA("ColorGradingEffect") then
-			child.Parent = nil
-			table.insert(effects, child)
-		end
-	end
-
 	local retroGrading = Instance.new("ColorGradingEffect")
 	retroGrading.Name = "PhotoboothRetroGrading"
 	retroGrading.TonemapperPreset = Enum.TonemapperPreset.Retro
 	retroGrading.Parent = Lighting
 
 	return SceneControl.once(function()
-		undoGradedLighting()
+		unhideClouds()
 		setAtmosphereHidden(false)
-
 		Lighting.ExposureCompensation = exposureCompensation
-
 		retroGrading:Destroy()
-		for _, effect in effects do
-			effect.Parent = Lighting
-		end
 	end)
 end
 

--- a/src/Main/Photo/SceneControl.luau
+++ b/src/Main/Photo/SceneControl.luau
@@ -230,13 +230,11 @@ function SceneControl.getAtmosphereHider()
 end
 
 function SceneControl.isGradedLightingRequired()
-	if not Lighting:FindFirstChildWhichIsA("Atmosphere") then
-		local children = Lighting:GetChildren()
-		for i = #children, 1, -1 do
-			local child = children[i]
-			if child:IsA("ColorGradingEffect") and child.Enabled then
-				return child.TonemapperPreset ~= Enum.TonemapperPreset.Retro
-			end
+	local children = Lighting:GetChildren()
+	for i = #children, 1, -1 do
+		local child = children[i]
+		if child:IsA("ColorGradingEffect") and child.Enabled then
+			return child.TonemapperPreset ~= Enum.TonemapperPreset.Retro
 		end
 	end
 	return true
@@ -272,11 +270,24 @@ function SceneControl.applyRetroLighting()
 	retroGrading.TonemapperPreset = Enum.TonemapperPreset.Retro
 	retroGrading.Parent = Lighting
 
+	local effects = {}
+	for _, child in Lighting:GetChildren() do
+		if child:IsA("ColorGradingEffect") then
+			child.Parent = nil
+			table.insert(effects, child)
+		end
+	end
+
 	return SceneControl.once(function()
 		unhideClouds()
 		setAtmosphereHidden(false)
+
 		Lighting.ExposureCompensation = exposureCompensation
 		retroGrading:Destroy()
+
+		for _, effect in effects do
+			effect.Parent = Lighting
+		end
 	end)
 end
 

--- a/src/Main/Photo/SceneControl.luau
+++ b/src/Main/Photo/SceneControl.luau
@@ -265,11 +265,6 @@ function SceneControl.applyRetroLighting()
 	local exposureCompensation = Lighting.ExposureCompensation
 	Lighting.ExposureCompensation = 0
 
-	local retroGrading = Instance.new("ColorGradingEffect")
-	retroGrading.Name = "PhotoboothRetroGrading"
-	retroGrading.TonemapperPreset = Enum.TonemapperPreset.Retro
-	retroGrading.Parent = Lighting
-
 	local effects = {}
 	for _, child in Lighting:GetChildren() do
 		if child:IsA("ColorGradingEffect") then
@@ -278,16 +273,22 @@ function SceneControl.applyRetroLighting()
 		end
 	end
 
+	local retroGrading = Instance.new("ColorGradingEffect")
+	retroGrading.Name = "PhotoboothRetroGrading"
+	retroGrading.TonemapperPreset = Enum.TonemapperPreset.Retro
+	retroGrading.Parent = Lighting
+
 	return SceneControl.once(function()
 		unhideClouds()
 		setAtmosphereHidden(false)
 
 		Lighting.ExposureCompensation = exposureCompensation
-		retroGrading:Destroy()
 
 		for _, effect in effects do
 			effect.Parent = Lighting
 		end
+
+		retroGrading:Destroy()
 	end)
 end
 

--- a/src/Main/Photo/SceneControl.luau
+++ b/src/Main/Photo/SceneControl.luau
@@ -85,22 +85,6 @@ local function freezeEmitters()
 	end)
 end
 
-local function hideColorCorrections()
-	local effects = {}
-	for _, child in Lighting:GetChildren() do
-		if child:IsA("ColorCorrectionEffect") then
-			table.insert(effects, child)
-			child.Parent = nil
-		end
-	end
-
-	return SceneControl.once(function()
-		for _, effect in effects do
-			effect.Parent = Lighting
-		end
-	end)
-end
-
 -- Public
 
 function SceneControl.once<T..., U...>(callback: (T...) -> U...)
@@ -196,6 +180,22 @@ function SceneControl.hideScreenUI()
 	end)
 end
 
+function SceneControl.hideColorCorrections()
+	local effects = {}
+	for _, child in Lighting:GetChildren() do
+		if child:IsA("ColorCorrectionEffect") then
+			table.insert(effects, child)
+			child.Parent = nil
+		end
+	end
+
+	return SceneControl.once(function()
+		for _, effect in effects do
+			effect.Parent = Lighting
+		end
+	end)
+end
+
 function SceneControl.getAppliedColorCorrectionCopy()
 	local effects = {}
 	for _, child in Lighting:GetChildren() do
@@ -243,8 +243,6 @@ function SceneControl.isGradedLightingRequired()
 end
 
 function SceneControl.applyGradedLighting()
-	local undoHideColorCorrections = hideColorCorrections()
-
 	local clouds = {}
 	for _, child in workspace.Terrain:GetChildren() do
 		if child:IsA("Clouds") then
@@ -254,7 +252,6 @@ function SceneControl.applyGradedLighting()
 	end
 
 	return SceneControl.once(function()
-		undoHideColorCorrections()
 		for _, cloud in clouds do
 			cloud.Parent = workspace.Terrain
 		end
@@ -263,7 +260,6 @@ end
 
 function SceneControl.applyRetroLighting()
 	local undoGradedLighting = SceneControl.applyGradedLighting()
-	local undoHideColorCorrections = hideColorCorrections()
 	local setAtmosphereHidden = SceneControl.getAtmosphereHider()
 
 	setAtmosphereHidden(true)
@@ -286,8 +282,6 @@ function SceneControl.applyRetroLighting()
 
 	return SceneControl.once(function()
 		undoGradedLighting()
-		undoHideColorCorrections()
-
 		setAtmosphereHidden(false)
 
 		Lighting.ExposureCompensation = exposureCompensation


### PR DESCRIPTION
Color correction and clouds were not being properly handled in the atmosphere case. This PR fixes this by moving them to the top of the capture process so they must always be called.