### PR TITLE
Fix new studio camera beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [2.6.5] - 2026/07/28
+- Fix auto capture new studio camera beta support
+
 ### [2.6.4] - 2026/07/23
 - Unify right click menu across both the post processing and gallery apps
 - Fix color correction application on atmosphere present captures

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
@@ -16,6 +16,8 @@ local RenderPriorities = require(appRoot.RenderPriorities)
 local AnimationManager = require(script.AnimationManager)
 local PointCloud = require(script.PointCloud)
 
+local CAMERA_TYPE = Enum.CameraType.Scriptable
+
 local YAW_INIT = math.pi
 local PITCH_INIT = 0
 local PITCH_LIMIT = math.rad(89)
@@ -195,11 +197,16 @@ local function viewProjectionEdgeHits(cloud: { Vector3 }, axis: "X" | "Y", depth
 	return max, min
 end
 
-local function getStudioSetting<T>(key: string, default: T)
-	local success, value = pcall(function()
-		return (settings().Studio :: any)[key] :: T
-	end)
-	return if success then value else default
+local function getStudioSetting<T>(keys: { string }, default: T): T
+	for _, key in keys do
+		local success, value = pcall(function()
+			return (settings().Studio :: any)[key] :: T
+		end)
+		if success then
+			return value
+		end
+	end
+	return default
 end
 
 -- Methods
@@ -231,15 +238,17 @@ function AutoCaptureControllerClass._listenOrbitInput(self: AutoCaptureControlle
 	local rotating = false
 	local cleanupTrove = Trove.new()
 
-	cleanupTrove:Add(UserInputService.InputBegan:Connect(function(input, gameProcessed)
-		if not gameProcessed and input.UserInputType == Enum.UserInputType.MouseButton2 then
+	cleanupTrove:Add(UserInputService.InputBegan:Connect(function(input, _gameProcessed)
+		if input.UserInputType == Enum.UserInputType.MouseButton2 then
 			rotating = true
+			UserInputService.MouseBehavior = Enum.MouseBehavior.LockCurrentPosition
 		end
 	end))
 
 	cleanupTrove:Add(UserInputService.InputEnded:Connect(function(input)
 		if input.UserInputType == Enum.UserInputType.MouseButton2 then
 			rotating = false
+			UserInputService.MouseBehavior = Enum.MouseBehavior.Default
 		end
 	end))
 
@@ -337,7 +346,7 @@ function AutoCaptureControllerClass._hookOrbital(self: AutoCaptureController)
 				size = Vector2.new(1, 1),
 			})
 
-		camera.CameraType = Enum.CameraType.Scriptable
+		camera.CameraType = CAMERA_TYPE
 		camera.CFrame = distortedCF
 		camera.Focus = distortedCF
 
@@ -414,7 +423,7 @@ function AutoCaptureControllerClass._hookPointCloud(self: AutoCaptureController)
 				size = Vector2.new(1, 1),
 			})
 
-		camera.CameraType = Enum.CameraType.Scriptable
+		camera.CameraType = CAMERA_TYPE
 		camera.CFrame = distortedCF
 		camera.Focus = distortedCF
 
@@ -446,18 +455,33 @@ function AutoCaptureControllerClass._hookFree(self: AutoCaptureController)
 
 	local position = startCF.Position
 	local pitch, yaw = startCF:ToEulerAnglesYXZ()
+	local rotating = false
 	local moveSpeed = 0
 
 	local function isShiftDown()
 		return UserInputService:IsKeyDown(Enum.KeyCode.LeftShift) or UserInputService:IsKeyDown(Enum.KeyCode.RightShift)
 	end
 
+	cleanupTrove:Add(UserInputService.InputBegan:Connect(function(input, _gameProcessed)
+		if input.UserInputType == Enum.UserInputType.MouseButton2 then
+			rotating = true
+			UserInputService.MouseBehavior = Enum.MouseBehavior.LockCurrentPosition
+		end
+	end))
+
+	cleanupTrove:Add(UserInputService.InputEnded:Connect(function(input)
+		if input.UserInputType == Enum.UserInputType.MouseButton2 then
+			rotating = false
+			UserInputService.MouseBehavior = Enum.MouseBehavior.Default
+		end
+	end))
+
 	cleanupTrove:Add(UserInputService.InputChanged:Connect(function(input, _gameProcessed)
 		if self.isInputFrozen then
 			return
 		end
 
-		if input.UserInputType == Enum.UserInputType.MouseMovement then
+		if rotating and input.UserInputType == Enum.UserInputType.MouseMovement then
 			yaw -= input.Delta.X * FREE_LOOK_SENSITIVITY
 			pitch = math.clamp(pitch - input.Delta.Y * FREE_LOOK_SENSITIVITY, -PITCH_LIMIT, PITCH_LIMIT)
 		end
@@ -472,14 +496,14 @@ function AutoCaptureControllerClass._hookFree(self: AutoCaptureController)
 		local dynamic = self.dynamicObservableState:get()
 
 		local camera = workspace.CurrentCamera
-		camera.CameraType = Enum.CameraType.Scriptable
+		camera.CameraType = CAMERA_TYPE
 		camera.FieldOfView = dynamic.fov
 
 		local rotation = CFrame.fromEulerAnglesYXZ(pitch, yaw, 0)
 
 		if not self.isInputFrozen then
-			local studioCameraSpeed = getStudioSetting("Camera Speed", 1.5) * 10
-			local studioShiftSpeed = getStudioSetting("Shift Speed", 0.2) * 10
+			local studioCameraSpeed = getStudioSetting({ "Camera Speed" }, 1.5) * 10
+			local studioShiftSpeed = getStudioSetting({ "Camera Shift Speed", "Shift Speed" }, 0.2) * 10
 
 			if isShiftDown() then
 				moveSpeed = studioShiftSpeed

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
@@ -502,8 +502,8 @@ function AutoCaptureControllerClass._hookFree(self: AutoCaptureController)
 		local rotation = CFrame.fromEulerAnglesYXZ(pitch, yaw, 0)
 
 		if not self.isInputFrozen then
-			local studioCameraSpeed = getStudioSetting({ "Camera Speed" }, 1.5) * 10
-			local studioShiftSpeed = getStudioSetting({ "Camera Shift Speed", "Shift Speed" }, 0.2) * 10
+			local studioCameraSpeed = 15 --getStudioSetting({ "Camera Speed" }, 1.5) * 10
+			local studioShiftSpeed = 2 --getStudioSetting({ "Camera Shift Speed", "Shift Speed" }, 0.2) * 10
 
 			if isShiftDown() then
 				moveSpeed = studioShiftSpeed


### PR DESCRIPTION
# Problem

The new studio camera navigation beta broke the auto capture.
https://devforum.roblox.com/t/studio-beta-updates-to-studio-camera-that-simplify-navigation/4751512

# Solution

A number of changes needed to be made to support the new camera:
- Right click is now a game processed event
- The mouse behavior needs to be manually locked in place with the scriptable camera
- Use fixed camera speed settings b/c we can't use the scroll wheel control on while in scriptable