### PR TITLE
Fix reopen crop reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Unreleased
+- Fixes the cropped viewport rect getting reset whenever the viewport app was closed and reopened
+
 ### [2.6.5] - 2026/07/28
 - Fix auto capture new studio camera beta support
 

--- a/src/Main/UserInterface/Apps/Viewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/init.luau
@@ -107,9 +107,7 @@ local function appComponent(props: { Button: PluginToolbarButton })
 		local trove = Trove.new()
 		trove:Add(props.Button.Click:Connect(function()
 			local newIsEnabled = not isEnabled
-			if newIsEnabled then
-				updateCaptureRectRef(createCenterRect(Vector2.new(0.5, 0.5)))
-			else
+			if not newIsEnabled then
 				ViewportApp.clearAllRectRequests()
 			end
 			setIsEnabled(newIsEnabled)


### PR DESCRIPTION
When you open and close the viewport app your crop would always get reset. This PR changes that so that the rect you set gets retained throughout your session