### PR TITLE
Fix unmount rect jumping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Unreleased
 - Fixes the cropped viewport rect getting reset whenever the viewport app was closed and reopened
+- Fixes the cropped viewport rect jumping when the viewport was resized while in fullscreen
 
 ### [2.6.5] - 2026/07/28
 - Fix auto capture new studio camera beta support

--- a/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/CroppedViewport.story.luau
+++ b/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/CroppedViewport.story.luau
@@ -9,14 +9,17 @@ local CroppedViewport = require(script.Parent)
 return CreateStory.theme(function(props)
 	local isDisabled, setIsDisabled = React.useState(false)
 	local captureRectRef = React.useRef(Rect.new(0, 0, 512, 512))
+	local desiredCropRef = React.useRef(nil :: CroppedViewport.DesiredCrop?)
 	local updateCaptureRectRef = React.useCallback(function(rect: Rect)
 		captureRectRef.current = rect
+		desiredCropRef.current = nil
 	end, {})
 
 	return React.createElement(CroppedViewport, {
 		ScaleOS = Vector2.new(1, 1),
 		IsRectRequest = false,
 		CaptureRectRef = captureRectRef,
+		DesiredCropRef = desiredCropRef,
 		UpdateCaptureRectRef = updateCaptureRectRef,
 
 		OnReady = function(viewport)

--- a/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/init.luau
@@ -513,7 +513,7 @@ return function(props: Props)
 		Active = false,
 		ref = viewportRef,
 	}, {
-		Core = props.Visible and isReady and React.createElement(CroppedViewport, {
+		Core = isReady and React.createElement(CroppedViewport, {
 			ScaleOS = props.ScaleOS,
 			IsRectRequest = props.IsRectRequest,
 			ViewportRect = viewportRect,

--- a/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/Components/CroppedViewport/init.luau
@@ -55,7 +55,7 @@ local MIN_CAPTURE_WIDTH = math.max(MIN_CAPTURE_HEIGHT, ACTION_BAR.Width, ALIGN_B
 local MAX_CAPTURE_HEIGHT = Constants.MaxCaptureRectSize.Y
 local MAX_CAPTURE_WIDTH = Constants.MaxCaptureRectSize.X
 
-type DesiredCrop = {
+export type DesiredCrop = {
 	centerScale: Vector2,
 	size: Vector2,
 }
@@ -200,6 +200,7 @@ end
 
 local function useCaptureRect(
 	captureRef: { current: Rect },
+	desiredCropRef: { current: DesiredCrop? },
 	updateCaptureRef: (Rect) -> (),
 	scaledViewportRect: Rect,
 	scaleOS: Vector2
@@ -211,9 +212,17 @@ local function useCaptureRect(
 		{ scaledViewportRect, scaleOS } :: { any }
 	)
 
-	local desiredCropRef = React.useRef(toDesiredCrop(captureRef.current, scaledViewportRect, scaleOS))
+	local getDesiredCaptureRect = React.useCallback(function()
+		local desiredCrop = desiredCropRef.current
+		if desiredCrop then
+			return fromDesiredCrop(desiredCrop, scaledViewportRect, scaleOS)
+		end
+		return captureRef.current
+	end, { scaledViewportRect, scaleOS } :: { any })
+
 	local captureRect, setCaptureRect = React.useState(function()
-		local clampedCaptureRect = getClampedCaptureRect(captureRef.current, Vector2.zero, Vector2.zero, true, true)
+		local clampedCaptureRect =
+			getClampedCaptureRect(getDesiredCaptureRect(), Vector2.zero, Vector2.zero, true, true)
 		return RenderRect.fromRect(clampedCaptureRect)
 	end)
 
@@ -233,27 +242,24 @@ local function useCaptureRect(
 	)
 
 	local setCaptureSize = React.useCallback(function(dimensions: Vector2)
-		local viewportSize = Vector2.new(scaledViewportRect.Width, scaledViewportRect.Height)
-		local center = scaledViewportRect.Min + desiredCropRef.current.centerScale * viewportSize
+		local desiredRect = getDesiredCaptureRect()
+		local center = (desiredRect.Min + desiredRect.Max) / 2
 		local rect = Rect.new(center - dimensions / 2, center + dimensions / 2)
 		setCaptureRectClamped(rect, Vector2.zero, Vector2.zero, true, false)
-	end, { setCaptureRectClamped } :: { any })
+	end, { getDesiredCaptureRect, setCaptureRectClamped } :: { any })
 
-	local updateCaptureRefRef = React.useRef((nil :: any) :: typeof(updateCaptureRef))
 	React.useEffect(function()
-		if updateCaptureRefRef.current ~= updateCaptureRef then
-			-- hard override (open / rect request): snap to the requested rect
-			updateCaptureRefRef.current = updateCaptureRef
-			setCaptureRectClamped(captureRef.current, Vector2.zero, Vector2.zero, true, true)
-		else
-			-- viewport moved/resized: keep the desired crop, only re-clamp it to the new bounds
-			local desiredRect = fromDesiredCrop(desiredCropRef.current, scaledViewportRect, scaleOS)
-			local clampedCaptureRect =
-				RenderRect.fromRect(getClampedCaptureRect(desiredRect, Vector2.zero, Vector2.zero, true, true))
-			captureRef.current = clampedCaptureRect
-			setCaptureRect(clampedCaptureRect)
+		local isOverride = desiredCropRef.current == nil
+		local clampedCaptureRect =
+			getClampedCaptureRect(getDesiredCaptureRect(), Vector2.zero, Vector2.zero, true, true)
+		local renderedCaptureRect = RenderRect.fromRect(clampedCaptureRect)
+
+		captureRef.current = renderedCaptureRect
+		if isOverride then
+			desiredCropRef.current = toDesiredCrop(clampedCaptureRect, scaledViewportRect, scaleOS)
 		end
-	end, { setCaptureRectClamped, updateCaptureRef })
+		setCaptureRect(renderedCaptureRect)
+	end, { getClampedCaptureRect, getDesiredCaptureRect, updateCaptureRef } :: { any })
 
 	return captureRect, setCaptureRectClamped, setCaptureSize
 end
@@ -262,6 +268,7 @@ export type Props = {
 	ScaleOS: Vector2,
 	IsRectRequest: boolean,
 	CaptureRectRef: { current: Rect },
+	DesiredCropRef: { current: DesiredCrop? },
 	UpdateCaptureRectRef: (Rect) -> (),
 	OnCapture: (Rect) -> (boolean, string?),
 	OnMaximize: () -> (),
@@ -283,8 +290,13 @@ local function CroppedViewport(props: Props & { ViewportRect: Rect })
 	local dragRectRef = React.useRef(Rect.new(0, 0, 0, 0))
 
 	local scaledViewportRect = useScaledViewportRect(props.ViewportRect, props.ScaleOS)
-	local captureRect, setCaptureRect, setCaptureSize =
-		useCaptureRect(props.CaptureRectRef, props.UpdateCaptureRectRef, scaledViewportRect, props.ScaleOS)
+	local captureRect, setCaptureRect, setCaptureSize = useCaptureRect(
+		props.CaptureRectRef,
+		props.DesiredCropRef,
+		props.UpdateCaptureRectRef,
+		scaledViewportRect,
+		props.ScaleOS
+	)
 
 	local renderedCaptureRect = RenderRect.fromRect(
 		Rect.new(
@@ -301,6 +313,7 @@ local function CroppedViewport(props: Props & { ViewportRect: Rect })
 	return React.createElement("Frame", {
 		BackgroundTransparency = 1,
 		Size = UDim2.fromScale(1, 1),
+		Visible = props.Visible,
 	}, {
 		Lense = React.createElement("Frame", {
 			BackgroundTransparency = 1,
@@ -505,6 +518,7 @@ return function(props: Props)
 			IsRectRequest = props.IsRectRequest,
 			ViewportRect = viewportRect,
 			CaptureRectRef = props.CaptureRectRef,
+			DesiredCropRef = props.DesiredCropRef,
 			UpdateCaptureRectRef = props.UpdateCaptureRectRef,
 			OnMaximize = props.OnMaximize,
 			OnCapture = props.OnCapture,

--- a/src/Main/UserInterface/Apps/Viewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/init.luau
@@ -72,13 +72,13 @@ end
 local function useCaptureRect()
 	local captureRectRef = React.useRef(createCenterRect(Vector2.new(0.5, 0.5)))
 	local desiredCropRef = React.useRef(nil :: CroppedViewport.DesiredCrop?)
-	local updateTicket, setUpdateTicket = React.useState(0)
+	local updateTicket, setUpdateTicket = React.useState(1)
 
 	local update = React.useCallback(function(newRect: Rect)
 		captureRectRef.current = newRect
 		desiredCropRef.current = nil
-		setUpdateTicket(function(count)
-			return count + 1
+		setUpdateTicket(function(ticket)
+			return -ticket
 		end)
 	end, { updateTicket })
 

--- a/src/Main/UserInterface/Apps/Viewport/init.luau
+++ b/src/Main/UserInterface/Apps/Viewport/init.luau
@@ -20,7 +20,6 @@ local RenderRect = require(bindingRoot.Helpers.RenderRect)
 
 local uiRoot = script:FindFirstAncestor("UserInterface")
 local ToolbarButton = require(uiRoot.Helpers.ToolbarButton)
-local Hooks = require(uiRoot.Hooks)
 
 local CroppedViewport = require(script.Components.CroppedViewport)
 local FullViewport = require(script.Components.FullViewport)
@@ -71,26 +70,28 @@ local function createCenterRect(scale: Vector2, scaleOS: Vector2?)
 end
 
 local function useCaptureRect()
-	-- we use a ref b/c in most cases we don't need to re-render the whole tree when we update this value
-	-- we have a custom update value which can be used to trigger re-renders, but it's used only when
-	-- there's a hard override we want to set (which doesn't occur often)
 	local captureRectRef = React.useRef(createCenterRect(Vector2.new(0.5, 0.5)))
-	local forceUpdate = Hooks.useUpdate()
+	local desiredCropRef = React.useRef(nil :: CroppedViewport.DesiredCrop?)
+	local updateTicket, setUpdateTicket = React.useState(0)
 
 	local update = React.useCallback(function(newRect: Rect)
 		captureRectRef.current = newRect
-		forceUpdate()
-	end, { forceUpdate })
+		desiredCropRef.current = nil
+		setUpdateTicket(function(count)
+			return count + 1
+		end)
+	end, { updateTicket })
 
-	return captureRectRef, update
+	return captureRectRef, desiredCropRef, update
 end
 
 local function appComponent(props: { Button: PluginToolbarButton })
 	local isEnabled, setIsEnabled = React.useState(false)
 	local rectRequest, removeRectRequest = useRectRequest()
-	local captureRectRef, updateCaptureRectRef = useCaptureRect()
-	local screenGuiRef = React.useRef(nil :: ScreenGui?)
+	local captureRectRef, desiredCropRef, updateCaptureRectRef = useCaptureRect()
+
 	local isFirstAppOpenRef = React.useRef(true)
+	local screenGuiRef = React.useRef(nil :: ScreenGui?)
 
 	local isCapturing = StateManager.temporary:useSpecific()(function(state)
 		return state.isCapturing
@@ -205,6 +206,7 @@ local function appComponent(props: { Button: PluginToolbarButton })
 				IsRectRequest = not not rectRequest,
 				ScaleOS = if rectRequest then rectRequest.scaleOS else scaleOS,
 				CaptureRectRef = captureRectRef,
+				DesiredCropRef = desiredCropRef,
 				UpdateCaptureRectRef = updateCaptureRectRef,
 				OnMaximize = onMinMax,
 				OnCapture = onCapture,


### PR DESCRIPTION
# Problem

The cropped viewport's core unmounted whenever the app swapped to fullscreen, and its viewport-relative crop died with it. So any viewport change while fullscreen - e.g. turning device emulation off - went untracked, and coming back out of fullscreen remounted fresh and snapped to the last absolute rect, which was still in the old viewport's pixel space. The rect landed well away from where it was left, because a fresh mount was indistinguishable from a genuine hard override (app open / rect request).

# Solution

Hide the cropped viewport instead of unmounting it, so it stays mounted and keeps re-clamping the desired crop as the viewport changes, and move the desired crop up to the viewport app so it also survives the app itself closing and reopening.