### PR TITLE
Fix pure black constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Unreleased
 - Fixes the cropped viewport rect getting reset whenever the viewport app was closed and reopened
 - Fixes the cropped viewport rect jumping when the viewport was resized while in fullscreen
+- Fixes fast reverse blend path trying to match a big-endian value with a little-endian one
 
 ### [2.6.5] - 2026/07/28
 - Fix auto capture new studio camera beta support

--- a/src/Main/Photo/Captures/Composers/ReverseBlend/Worker.luau
+++ b/src/Main/Photo/Captures/Composers/ReverseBlend/Worker.luau
@@ -2,7 +2,7 @@
 
 local COMPARE_MARGIN = 0
 local WHITE = 0xFFFFFFFF
-local BLACK = 0x000000FF
+local BLACK = 0xFF000000
 
 @native
 local function worker(


### PR DESCRIPTION
The fast path for pure black and white backgrounds was never firing b/c I accidentally wrote the pure black constant in big-endian. I fixed this by swapping it to little-endian which is how `buffer.readu32` reads the value.