### PR TITLE
Add distance scale mouse scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Unreleased
+- Add scroll wheel support for controlling the distance scale during orbital and point cloud auto capture modes
+
 ### [2.7.0] - 2026/08/02
 - Fixes the cropped viewport rect getting reset whenever the viewport app was closed and reopened
 - Fixes the cropped viewport rect jumping when the viewport was resized while in fullscreen

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
@@ -24,6 +24,10 @@ local PITCH_LIMIT = math.rad(89)
 
 local ORBIT_SENSITIVITY = 0.005
 
+local DISTANCE_SCALE_STEP = 1.05
+local DISTANCE_SCALE_MIN = 0.01
+local DISTANCE_SCALE_MAX = 100
+
 local FREE_LOOK_SENSITIVITY = 0.005
 local FREE_MOVE_SPEED_MAX = 1000
 
@@ -263,6 +267,13 @@ function AutoCaptureControllerClass._listenOrbitInput(self: AutoCaptureControlle
 				focus.yaw = focus.yaw - input.Delta.X * ORBIT_SENSITIVITY
 				focus.pitch = math.clamp(focus.pitch - input.Delta.Y * ORBIT_SENSITIVITY, -PITCH_LIMIT, PITCH_LIMIT)
 			end
+		elseif input.UserInputType == Enum.UserInputType.MouseWheel then
+			local factor = DISTANCE_SCALE_STEP ^ -input.Position.Z
+			self.dynamicObservableState:update()(function(state)
+				local scaled = math.round(state.distanceScale * factor * 1000) / 1000
+				state.distanceScale = math.clamp(scaled, DISTANCE_SCALE_MIN, DISTANCE_SCALE_MAX)
+				return state
+			end)
 		end
 	end))
 


### PR DESCRIPTION
When in auto capture the distance scale value was previously only controllable via inputting into the textbox. This has been changed based on user feedback to also allow you to control based on scroll wheel.